### PR TITLE
스프링 컨테이너와 스프링 빈

### DIFF
--- a/Spring-Basic/core/src/main/resources/appConfig.xml
+++ b/Spring-Basic/core/src/main/resources/appConfig.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="memberService" class="hello.core.member.service.MemberServiceImpl">
+        <constructor-arg name="memberRepository" ref="memberRepository"/>
+    </bean>
+
+    <bean id="orderService" class="hello.core.Order.service.OrderServiceImpl">
+        <constructor-arg name="memberRepository" ref="memberRepository"/>
+        <constructor-arg name="discountPolicy" ref="discountPolicy"/>
+    </bean>
+
+    <bean id="memberRepository" class="hello.core.member.repository.MemoryMemberRepository"/>
+
+    <bean id="discountPolicy" class="hello.core.discount.RateDiscountPolicy"/>
+</beans>

--- a/Spring-Basic/core/src/test/java/hello/core/beandefinition/BeanDefinitionTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/beandefinition/BeanDefinitionTest.java
@@ -1,0 +1,28 @@
+package hello.core.beandefinition;
+
+import hello.core.AppConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class BeanDefinitionTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @Test
+    @DisplayName("빈 설정 메타정보 확인")
+    void findApplicationBean() {
+        // when
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+
+        // then
+        for (String beanDefinitionName : beanDefinitionNames) {
+            BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinitionName);
+
+            if (beanDefinition.getRole() == BeanDefinition.ROLE_APPLICATION) {
+                System.out.println("beanDefinitionName = " + beanDefinitionName + " / beanDefinition" + beanDefinition);
+            }
+        }
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/beanfind/ApplicationContextBasicFindTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/beanfind/ApplicationContextBasicFindTest.java
@@ -1,0 +1,56 @@
+package hello.core.beanfind;
+
+import hello.core.AppConfig;
+import hello.core.member.service.MemberService;
+import hello.core.member.service.MemberServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ApplicationContextBasicFindTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @Test
+    @DisplayName("빈 이름으로 조회")
+    void findBeanByName() {
+        // when
+        MemberService memberService = ac.getBean("memberService", MemberService.class);
+
+        // then
+        assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+
+    @Test
+    @DisplayName("타입으로 조회")
+    void findBeanByType() {
+        // when
+        MemberService memberService = ac.getBean(MemberService.class);
+
+        // then
+        assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+
+    @Test
+    @DisplayName("구현 타입으로 조회")
+    void findBeanByImplementType() {
+        // when
+        MemberService memberService = ac.getBean("memberService", MemberServiceImpl.class);
+
+        // then
+        assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 빈 이름 조회")
+    void findBeanByName_X() {
+        // when
+        // then
+        assertThatThrownBy(() -> ac.getBean("xxxx"))
+                .isInstanceOf(NoSuchBeanDefinitionException.class);
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/beanfind/ApplicationContextExtendsFindTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/beanfind/ApplicationContextExtendsFindTest.java
@@ -1,0 +1,91 @@
+package hello.core.beanfind;
+
+import hello.core.discount.DiscountPolicy;
+import hello.core.discount.FixDiscountPolicy;
+import hello.core.discount.RateDiscountPolicy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ApplicationContextExtendsFindTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(TestConfig.class);
+
+
+    @Test
+    @DisplayName("부모 타입으로 조회 시, 자식이 둘 이상 있으면, 중복 오류가 발생한다.")
+    void findBeanByParentTypeDuplicate() {
+        // when
+        // then
+        assertThatThrownBy(() -> ac.getBean(DiscountPolicy.class))
+                .isInstanceOf(NoUniqueBeanDefinitionException.class);
+    }
+
+
+    @Test
+    @DisplayName("부모 타입으로 조회 시, 자식이 둘 이상 있으면, 빈 이름을 지정하면 된다.")
+    void findBeanByParentTypeBeanName() {
+        // when
+        DiscountPolicy rateDiscountPolicy = ac.getBean("rateDiscountPolicy", DiscountPolicy.class);
+
+        // then
+        assertThat(rateDiscountPolicy).isInstanceOf(RateDiscountPolicy.class);
+    }
+
+    @Test
+    @DisplayName("특정 하위 타입으로 조회")
+    void findBeanBySubType() {
+        // when
+        RateDiscountPolicy bean = ac.getBean(RateDiscountPolicy.class);
+
+        // then
+        assertThat(bean).isInstanceOf(RateDiscountPolicy.class);
+    }
+
+    @Test
+    @DisplayName("부모 타입으로 모두 조회")
+    void findAllBeanByParentType() {
+        // when
+        Map<String, DiscountPolicy> beansOfType = ac.getBeansOfType(DiscountPolicy.class);
+
+        // then
+        for (String key : beansOfType.keySet()) {
+            System.out.println("key = " + key + " / value = " + beansOfType.get(key));
+        }
+        assertThat(beansOfType.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("부모 타입으로 모두 조회 - Object")
+    void findAllBeanByObjectType() {
+        // when
+        Map<String, Object> beansOfType = ac.getBeansOfType(Object.class);
+
+        // then
+        for (String key : beansOfType.keySet()) {
+            System.out.println("key = " + key + " / value = " + beansOfType.get(key));
+        }
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        public DiscountPolicy rateDiscountPolicy() {
+            return new RateDiscountPolicy();
+        }
+
+        @Bean
+        public DiscountPolicy fixDiscountPolicy() {
+            return new FixDiscountPolicy();
+        }
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/beanfind/ApplicationContextInfoTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/beanfind/ApplicationContextInfoTest.java
@@ -1,0 +1,38 @@
+package hello.core.beanfind;
+
+import hello.core.AppConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class ApplicationContextInfoTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @Test
+    @DisplayName("모든 빈 출력")
+    void findAllBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String beanDefinitionName : beanDefinitionNames) {
+            Object bean = ac.getBean(beanDefinitionName);
+            System.out.println("name = " + beanDefinitionName + " / object = " + bean);
+        }
+    }
+
+    @Test
+    @DisplayName("애플리케이션 빈 출력")
+    void findApplicationBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String beanDefinitionName : beanDefinitionNames) {
+            BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinitionName);
+
+            // Role ROLE_APPLICATION: 직접 등록한 애플리케이션 빈
+            // Role ROLE_INFRASTRUCTURE: 스프링이 내부에서 사용하는 빈
+            if (beanDefinition.getRole() == BeanDefinition.ROLE_APPLICATION) {
+                Object bean = ac.getBean(beanDefinitionName);
+                System.out.println("name = " + beanDefinitionName + " / object = " + bean);
+            }
+        }
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/beanfind/ApplicationContextSameBeanFindTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/beanfind/ApplicationContextSameBeanFindTest.java
@@ -1,0 +1,68 @@
+package hello.core.beanfind;
+
+import hello.core.member.repository.MemberRepository;
+import hello.core.member.repository.MemoryMemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ApplicationContextSameBeanFindTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(SameBeanConfig.class);
+
+    @Test
+    @DisplayName("타입으로 조회 시, 같은 타입이 둘 이상 있으면, 중복 오류가 발생한다.")
+    void findBeanByTypeDuplicate() {
+        // when
+        // then
+        assertThatThrownBy(() -> ac.getBean(MemberRepository.class))
+                .isInstanceOf(NoUniqueBeanDefinitionException.class);
+    }
+
+    @Test
+    @DisplayName("타입으로 조회 시, 같은 타입이 둘 이상이면, 빈 이름을 지정하면 된다.")
+    void findBeanByName() {
+        // when
+        MemberRepository memberRepository = ac.getBean("memberRepository1", MemberRepository.class);
+
+        // then
+        assertThat(memberRepository).isInstanceOf(MemberRepository.class);
+    }
+
+    @Test
+    @DisplayName("특정 타입을 모두 조회")
+    void findAllBeanByType() {
+        // when
+        Map<String, MemberRepository> beansOfType = ac.getBeansOfType(MemberRepository.class);
+
+        // then
+        for (String key : beansOfType.keySet()) {
+            System.out.println("key = " + key + " / value = " + beansOfType.get(key));
+        }
+        System.out.println("beansOfType = " + beansOfType);
+
+        assertThat(beansOfType.size()).isEqualTo(2);
+    }
+
+    @Configuration
+    static class SameBeanConfig {
+
+        @Bean
+        public MemberRepository memberRepository1() {
+            return new MemoryMemberRepository();
+        }
+
+        @Bean
+        public MemberRepository memberRepository2() {
+            return new MemoryMemberRepository();
+        }
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/xml/XmlAppContextTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/xml/XmlAppContextTest.java
@@ -1,0 +1,24 @@
+package hello.core.xml;
+
+import hello.core.member.service.MemberService;
+import hello.core.member.service.MemberServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericXmlApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XmlAppContextTest {
+
+    @Test
+    void xmlAppContext() {
+        // given
+        ApplicationContext ac = new GenericXmlApplicationContext("appConfig.xml");
+
+        // when
+        MemberService memberService = ac.getBean("memberService", MemberService.class);
+
+        // then
+        assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+}


### PR DESCRIPTION
# 스프링 컨테이너 생성

ApplicationContext applicationContext = new AnotationConfigApplicationContext(AppConfig.class);

- ApplicationContext는 인터페이스로 스프링 컨테이너라고 한다.
- 스프링 컨테이너는 어노테이션 기반의 자바 설정이나, XML 기반으로 만들 수 있다.

## 스프링 컨테이너 생성 과정

1. 스프링 컨테이너 생성
- 스프링 컨테이너: new AnotationConfigApplicationContext()
- 구성 정보: AppConfig.class

2. 등록한 구성 정보를 활용하여 스프링 빈을 등록한다.
- 빈 이름은 기본적으로 메서드 이름을 사용한다.
- 빈 이름을 직접 부여할 수 있다.
	+ @ Bean(name="beanName")

3. 스프링 빈 의존관계를 설정한다.
- 설정 정보를 통해 의존관계 주입(DI)한다.

# 컨테이너에 등록된 빈 조회

## 모든 빈 조회

- ApplicationContext.getBeanDefinitionNames()
	+ 스프링에 등록된 모든 빈 이름을 조회한다.

- AnnotationConfigApplicationContext.getBeanDefinition()
	+ 빈 정보를 조회할 수 있다.
	
- BeanDefinition.getRole()
	+ Role ROLE_APPLICATION: 직접 등록한 애플리케이션 빈
	+ Role ROLE_INFRASTRUCTURE: 스프링이 내부에서 사용하는 빈
	
- ApplicationContext.getBean(beanName)
	+ 빈 이름으로 스프링 컨테이너에 등록된 인스턴스를 조회한다.

## 스프링 빈 조회

>존재하지 않는 빈 이름으로 조회하면,
NoSuchBeanDefinitionException 예외가 발생한다.

1. 빈 이름으로 조회
- ac.getBean("memberService")

2. 타입으로 조회
- ac.getBean(MemberService.class)

3. 구현 타입으로 조회
- ac.getBean(MemberServiceImpl.class)

## 동일한 타입의 빈 조회

>같은 타입이 둘 이상이면,
NoUniqueBeanDefinitionException 예외가 발생한다.

1. 빈 이름 지정 조회
- ac.getBean("memberRepository1", MemberRepository.class)

2. 특정 타입 빈 모두 조회
- ac.getBeansOfType(MemberRepository.class)
	+ key는 스프링 컨테이너에 등록된 빈 이름이다.

## 상속관계 빈 조회

#### 부모 타입으로 조회하면, 자식 타입도 함께 모두 조회된다.

>부모 타입으로 조회할 때, 자식이 둘 이상이면,
NoUniqueBeanDefinitionException 예외가 발생한다.

1. 자식이 둘 이상이면, 빈 이름 지정 조회
- ac.getBean("rateDiscountPolicy", DiscountPolicy.class)

2. 특정 자식 타입으로 조회
- ac.getBean(RateDiscountPolicy.class)

3. 부모 타입으로 모두 조회
- ac.getBeansOfType(DiscountPolicy.class)

>BeanFactory
> - 스프링 컨테이너의 최상위 인터페이스로, 스프링 빈을 관리하고 조회하는 역할을 한다.
> - getBean()을 제공한다.
>
>ApplicationContext
> - BeanFactory 기능을 확장하여 부가기능을 제공한다.
> - 부가기능
>	+ MessageSource: 메시지소스를 활용한 국제화 기능
>	+ EnvironmentCapable: 환경변수
>	+ ApplicationEventPublisher: 애플리케이션 이벤트
>	+ ResourceLoader: 편리한 리소스 조회

# 다양한 설정 형식

>스프링 컨테이너는 다양한 형식의 설정 정보를 받아드릴 수 있게 유연하게 설계되었다.
ApplicationContext 구현 클래스를 통해 다양한 형식의 설정 정보를 넘길 수 있다.

- 자바 코드
	+ 어노테이션 기반 자바 코드 설정
	+ AnnotationConfigApplicationContext 클래스를 사용해서 자바 코드로된 설정 정보를 넘기면 된다.

- XML 설정
	+ XML을 사용하면 컴파일 없이 빈 설정 정보를 변경할 수 있다.
	+ GenericXmlApplicationContext 클래스를 사용해서 xml 설정 정보를 넘기면 된다.
	
# 스프링 빈 설정 메타정보

스프링은 BeanDefinition 추상화를 통해 다양한 설정 형식을 지원한다.

#### 즉, 역할과 구현을 개념적으로 나눴다.

- 자바 코드를 읽어서 BeanDefinition을 만든다.
- XML을 읽어서 BeanDefinition을 만든다.
- 따라서 스프링 컨테이너는 자바 코드인지, XML인지 상관 없이 BeanDefinition만 알면 된다.
- BeanDefinition을 빈 설정 메타정보라고 한다.
	+ @ Bean, <bean> 하나당 각각 메타 정보가 생성된다.
	
![image](https://user-images.githubusercontent.com/50781066/227843789-fc53dfa7-c59c-4a3d-8300-5a763b06349d.png)

- AnnotationConfigApplicationContext 는 AnnotatedBeanDefinitionReader 를 사용해서 AppConfig.class 설정 정보를 읽고 BeanDefinition 을 생성한다.
- GenericXmlApplicationContext 는 XmlBeanDefinitionReader 를 사용해서 appConfig.xml 설정 정보를 읽고 BeanDefinition 을 생성한다.
- 새로운 형식의 설정 정보가 추가되면, XxxBeanDefinitionReader를 만들어서 BeanDefinition 을 생성하면 된다.

>BeanDefinition 정보
>
> - BeanClassName: 생성할 빈의 클래스 명(자바 설정 처럼 팩토리 역할의 빈을 사용하면 없음)
> - factoryBeanName: 팩토리 역할의 빈을 사용할 경우 이름, 예) appConfig
> - factoryMethodName: 빈을 생성할 팩토리 메서드 지정, 예) memberService
> - Scope: 싱글톤(기본값)lazyInit: 스프링 컨테이너를 생성할 때 빈을 생성하는 것이 아니라, 실제 빈을 사용할 때 까지 최대한 생성을 지연처리 하는지 여부
> - InitMethodName: 빈을 생성하고, 의존관계를 적용한 뒤에 호출되는 초기화 메서드 명
> - DestroyMethodName: 빈의 생명주기가 끝나서 제거하기 직전에 호출되는 메서드 명
> - Constructor arguments, Properties: 의존관계 주입에서 사용한다. (자바 설정 처럼 팩토리 역할의 빈을 사용하면 없음)