### PR TITLE
싱글톤 컨테이너

### DIFF
--- a/Spring-Basic/core/src/main/java/hello/core/AppConfig.java
+++ b/Spring-Basic/core/src/main/java/hello/core/AppConfig.java
@@ -14,23 +14,45 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class AppConfig {
 
+    // @Bean memberService -> new MemoryMemberRepository()
+    // @Bean orderService -> new MemoryMemberRepository(), new RateDiscountPolicy()
+
+    // 예상 log
+    // call AppConfig.memberService
+    // call AppConfig.memberRepository
+    // call AppConfig.orderService
+    // call AppConfig.memberRepository
+    // call AppConfig.discountPolicy
+    // call AppConfig.memberRepository
+    // call AppConfig.discountPolicy
+
+    // 실제 log
+    // call AppConfig.memberService
+    // call AppConfig.memberRepository
+    // call AppConfig.orderService
+    // call AppConfig.discountPolicy
+
     @Bean
     public MemberService memberService() {
+        System.out.println("call AppConfig.memberService");
         return new MemberServiceImpl(memberRepository());
     }
 
     @Bean
     public OrderService orderService() {
+        System.out.println("call AppConfig.orderService");
         return new OrderServiceImpl(memberRepository(), discountPolicy());
     }
 
     @Bean
     public MemberRepository memberRepository() {
+        System.out.println("call AppConfig.memberRepository");
         return new MemoryMemberRepository();
     }
 
     @Bean
     public DiscountPolicy discountPolicy() {
+        System.out.println("call AppConfig.discountPolicy");
         return new RateDiscountPolicy();
     }
 }

--- a/Spring-Basic/core/src/main/java/hello/core/Order/service/OrderServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/Order/service/OrderServiceImpl.java
@@ -22,4 +22,9 @@ public class OrderServiceImpl implements OrderService {
 
         return new Order(memberId, itemName, itemPrice, discountPrice);
     }
+
+    // 테스트 용도
+    public MemberRepository getMemberRepository() {
+        return memberRepository;
+    }
 }

--- a/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
@@ -20,4 +20,9 @@ public class MemberServiceImpl implements MemberService {
     public Member findMember(Long memberId) {
         return memberRepository.findById(memberId);
     }
+
+    // 테스트 용도
+    public MemberRepository getMemberRepository() {
+        return memberRepository;
+    }
 }

--- a/Spring-Basic/core/src/test/java/hello/core/singleton/ConfigurationSingletonTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/singleton/ConfigurationSingletonTest.java
@@ -1,0 +1,37 @@
+package hello.core.singleton;
+
+import hello.core.AppConfig;
+import hello.core.Order.service.OrderServiceImpl;
+import hello.core.member.repository.MemberRepository;
+import hello.core.member.service.MemberServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigurationSingletonTest {
+
+    @Test
+    void configurationTest() {
+        // given
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+        // when
+        MemberServiceImpl memberService = ac.getBean("memberService", MemberServiceImpl.class);
+        OrderServiceImpl orderService = ac.getBean("orderService", OrderServiceImpl.class);
+        MemberRepository memberRepository = ac.getBean("memberRepository", MemberRepository.class);
+
+        MemberRepository memberRepository1 = memberService.getMemberRepository();
+        MemberRepository memberRepository2 = orderService.getMemberRepository();
+
+        // then
+        // 모두 같은 인스턴스를 참고하고 있다.
+        System.out.println("memberService -> memberRepository = " + memberRepository1);
+        System.out.println("orderService -> memberRepository = " + memberRepository2);
+        System.out.println("memberRepository = " + memberRepository);
+
+        assertThat(memberRepository1).isSameAs(memberRepository);
+        assertThat(memberRepository2).isSameAs(memberRepository);
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/singleton/ConfigurationSingletonTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/singleton/ConfigurationSingletonTest.java
@@ -34,4 +34,18 @@ public class ConfigurationSingletonTest {
         assertThat(memberRepository1).isSameAs(memberRepository);
         assertThat(memberRepository2).isSameAs(memberRepository);
     }
+
+    @Test
+    void configurationDeep() {
+        // given
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+        // when
+        // AppConfig도 스프링 빈으로 등록된다.
+        AppConfig bean = ac.getBean(AppConfig.class);
+
+        // then
+        System.out.println("bean = " + bean.getClass());
+        // 출력: bean = class hello.core.AppConfig$$SpringCGLIB$$0
+    }
 }

--- a/Spring-Basic/core/src/test/java/hello/core/singleton/SingletonService.java
+++ b/Spring-Basic/core/src/test/java/hello/core/singleton/SingletonService.java
@@ -1,0 +1,16 @@
+package hello.core.singleton;
+
+public class SingletonService {
+
+    // 1. static 영역에 객체를 딱 1개만 생성한다.
+    private static final SingletonService instance = new SingletonService();
+
+    // 2. public으로 열어서 객체 인스턴스가 필요하면 이 static 메서드를 통해서만 조회하도록 허용한다.
+    public static SingletonService getInstance() {
+        return instance;
+    }
+
+    // 3. 생성자를 private으로 선언해서 외부에서 new 키워드를 사용한 객체 생성을 못하게 막는다.
+    private SingletonService() {
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/singleton/SingletonTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/singleton/SingletonTest.java
@@ -4,6 +4,8 @@ import hello.core.AppConfig;
 import hello.core.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,5 +51,26 @@ public class SingletonTest {
 
         // singletonService1 == singletonService2
         assertThat(singletonService1).isSameAs(singletonService2);
+    }
+
+    @Test
+    @DisplayName("스프링 컨테이너와 싱글톤")
+    void springContainer() {
+        // given
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+        // when
+        // 1. 조회: 호출할 때 마다 같은 객체를 반환
+        MemberService memberService1 = ac.getBean("memberService", MemberService.class);
+        // 2. 조회: 호출할 때 마다 같은 객체를 반환
+        MemberService memberService2 = ac.getBean("memberService", MemberService.class);
+
+        // then
+        // 참조 값이 같은 것을 확인
+        System.out.println("memberService1 = " + memberService1);
+        System.out.println("memberService2 = " + memberService2);
+
+        // memberService1 == memberService2
+        assertThat(memberService1).isSameAs(memberService2);
     }
 }

--- a/Spring-Basic/core/src/test/java/hello/core/singleton/SingletonTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/singleton/SingletonTest.java
@@ -1,0 +1,32 @@
+package hello.core.singleton;
+
+import hello.core.AppConfig;
+import hello.core.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SingletonTest {
+
+    @Test
+    @DisplayName("스프링 없는 순수한 DI 컨테이너")
+    void pureContainer() {
+        // given
+        AppConfig appConfig = new AppConfig();
+
+        // when
+        // 1. 조회: 호출할 때 마다 객체를 생성
+        MemberService memberService1 = appConfig.memberService();
+        // 2. 조회: 호출할 때 마다 객체를 생성
+        MemberService memberService2 = appConfig.memberService();
+
+        // then
+        // 참조 값이 다른 것을 확인
+        System.out.println("memberService1 = " + memberService1);
+        System.out.println("memberService2 = " + memberService2);
+
+        // memberService1 != memberService2
+        assertThat(memberService1).isNotSameAs(memberService2);
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/singleton/SingletonTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/singleton/SingletonTest.java
@@ -29,4 +29,25 @@ public class SingletonTest {
         // memberService1 != memberService2
         assertThat(memberService1).isNotSameAs(memberService2);
     }
+
+    @Test
+    @DisplayName("싱글톤 패턴을 적용한 객체 사용")
+    void singletonServiceTest() {
+        // private으로 생성자를 막아두었기 때문에, 컴파일 오류가 발생한다.
+        // new SingletonService();
+
+        // when
+        // 1. 조회: 호출할 때 마다 같은 객체를 반환
+        SingletonService singletonService1 = SingletonService.getInstance();
+        // 2. 조회: 호출할 때 마다 같은 객체를 반환
+        SingletonService singletonService2 = SingletonService.getInstance();
+
+        // then
+        // 참조 값이 같은 것을 확인
+        System.out.println("singletonService1 = " + singletonService1);
+        System.out.println("singletonService2 = " + singletonService2);
+
+        // singletonService1 == singletonService2
+        assertThat(singletonService1).isSameAs(singletonService2);
+    }
 }

--- a/Spring-Basic/core/src/test/java/hello/core/singleton/StatefulService.java
+++ b/Spring-Basic/core/src/test/java/hello/core/singleton/StatefulService.java
@@ -1,0 +1,15 @@
+package hello.core.singleton;
+
+public class StatefulService {
+
+    private int price;  // 상태를 유지하는 필드
+
+    public void order(String name, int price) {
+        System.out.println("name = " + name + " / price = " + price);
+        this.price = price;  // 여기가 문제!
+    }
+
+    public int getPrice() {
+        return price;
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/singleton/StatefulServiceTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/singleton/StatefulServiceTest.java
@@ -1,0 +1,41 @@
+package hello.core.singleton;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StatefulServiceTest {
+
+    @Test
+    void statefulServiceSingleton() {
+        // given
+        ApplicationContext ac = new AnnotationConfigApplicationContext(TestConfig.class);
+        StatefulService statefulService1 = ac.getBean(StatefulService.class);
+        StatefulService statefulService2 = ac.getBean(StatefulService.class);
+
+        // when
+        //ThreadA: A사용자 10000원 주문
+        statefulService1.order("userA", 10000);
+        //ThreadB: B사용자 20000원 주문
+        statefulService2.order("userB", 20000);
+
+        //ThreadA: A사용자 주문 금액 조회
+        int price = statefulService1.getPrice();
+
+        // then
+        //ThreadA: A사용자는 10000원을 기대했지만, 기대와 다르게 20000원 출력
+        System.out.println("price = " + price);
+
+        assertThat(statefulService1.getPrice()).isEqualTo(20000);
+    }
+
+    static class TestConfig {
+        @Bean
+        public StatefulService statefulService() {
+            return new StatefulService();
+        }
+    }
+}


### PR DESCRIPTION
# 순수한 DI 컨테이너

- AppConfig.memberService()를 통해서 객체를 생성한다.
- 하지만 AppConfig는 요청을 할 때마다 객체를 새로 생성하고, 소멸된다.
	+ 메모리 낭비가 심하다.
	
# 싱글톤 패턴

- 클래스의 인스턴스가 1개만 생성되는 것을 보장하는 디자인 패턴이다.
	+ private 생성자를 통해 new 키워드를 사용하지 못하도록 막아 한 개의 인스턴스를 보장한다.
	
1. SingletonService 클래스에서 미리 인스턴스를 하나 생성한다.
2. 인스턴스는 getInstance() 메서드를 통해서만 조회할 수 있도록 한다.
3. 생성자를 private으로 추가로 인스턴스가 생성되는 것을 막는다.

>싱글톤 패턴을 적용하면 요청이 올 때마다 객체를 생성하는 것이 아니라, 이미 만들어진 객체를 공유해서 효율적으로 사용할 수 있다.
하지만 싱글톤 패턴은 수많은 문제점들을 가지고 있다.
>
> - 구현 클래스에 의존한다.(DIP 위반)
> - 구현 클래스에 의존하면 OCP를 위반할 가능성이 높다.
> - 테스트하기 까다롭다.
> - 결론적으로 유연성이 떨어진다.

## 스프링 컨테이너

#### 스프링 컨테이너는 싱글톤 패턴의 문제를 해결하면서, 객체를 싱글톤으로 관리한다.

- 스프링 컨테이너는 싱글톤 패턴으로 객체 인스턴스를 관리한다.
- 스프링 컨테이너는 싱글톤 객체를 생성하고, 관리하는 역할을 한다.
	+ 이런 기능을 싱글톤 레지스트리라고 한다.
- 싱글톤 패턴의 단점을 해결하면서, 객체를 싱글톤으로 유지할 수 있다.
	+ DIP, OCP, 테스트 등으로 부터 자유롭게 싱글톤을 사용할 수 있다.
	
ApplicationContext.getBean()을 통해 반환받은 객체는 같은 인스턴스이다.

>스프링의 기본 빈 등록 방식은 싱글톤이지만,
요청할 때 마다 새로운 객체를 생성해서 반환하는 기능도 제공한다.

## 싱글톤 방식의 주의사항

- 싱글톤 방식은 여러 클라이언트가 하나의 인스턴스를 공유하기 때문에 상태를 유지(stateful)하게 설계하면 안된다.
- 무상태(stateless)로 설계해야 한다.
	+ 특정 클라이언트에 의존적인 필드가 있으면 안된다.
	+ 가급적 읽기만 가능해야 한다.
	+ 필드 대신 자원이 공유되지 않는 지역변수, 파라미터, ThreadLocal 등을 사용해야 한다.

#### 스프링 빈의 필드에 공유 값을 설정하면 큰 장애가 발생할 수 있다.

## @ Configuration

AppConfig 코드를 보면 이상한 부분이 있다.

- MemoryMemberRepository 인스턴스를 생성하는 코드를 3번 호출한다.
	+ memberService 빈을 만드는 메서드에서 memberRepository()를 호출하고, new MemoryMemberRepository()를 호출한다.
	+ orderService 빈을 만드는 메서드에서 memberRepository()를 호출하고, new MemoryMemberRepository()를 호출한다.
	+ memberRepository 빈을 만드는 메서드에서 new MemoryMemberRepository()를 호출한다.
- 하지만 실제로는 1번만 호출된다.

## @ Configuration과 바이트코드 조작

#### 스프링은 @ Configuration을 적용한 구성 정보에는 CGLIB 바이트코드 조작 라이브러리를 사용해서 싱글톤이 되도록 보장한다.

AnnotationConfigApplicationContext에 파라미터로 넘긴 값도 스프링 빈으로 등록된다.
따라서 AppConfig 또한 스프링 빈으로 등록된다.

스프링 컨테이너에 등록된 AppConfig 정보를 조회하면 xxxCGLIB가 붙은 다른 클래스명이 조회된다.

- 실제 스프링 컨테이너에 등록된 빈은 AppConfig가 아닌 AppConfig를 상속받은 임의의 다른 클래스다.
- 대략적인 로직
	+ 이미 스프링 빈이 존재하면 존재하는 빈을 반환
	+ 스프링 빈이 존재하지 않는다면 생성해서 빈으로 등록하고 반환하는 코드가 동적으로 만들어질다.
- 따라서 싱글톤이 보장된다.

>@ Configuration 없이 @ Bean만 적용하면,
>
> - 스프링 빈으로 등록된다.
> - 하지만 싱글톤을 보장하지 않는다.
>	+ 실제로 new MemoryMemberRepository()가 3번 호출된다.
> - 따라서 스프링 설정 정보는 @ Configuration을 사용해야 한다.