### PR TITLE
컴포넌트 스캔

### DIFF
--- a/Spring-Basic/core/src/main/java/hello/core/AutoAppConfig.java
+++ b/Spring-Basic/core/src/main/java/hello/core/AutoAppConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ComponentScan(
+        basePackages = "hello.core.member",
+        basePackageClasses = AutoAppConfig.class,
         excludeFilters = @ComponentScan.Filter(classes = Configuration.class)
 )
 public class AutoAppConfig {

--- a/Spring-Basic/core/src/main/java/hello/core/AutoAppConfig.java
+++ b/Spring-Basic/core/src/main/java/hello/core/AutoAppConfig.java
@@ -1,0 +1,12 @@
+package hello.core;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(
+        excludeFilters = @ComponentScan.Filter(classes = Configuration.class)
+)
+public class AutoAppConfig {
+
+}

--- a/Spring-Basic/core/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/Spring-Basic/core/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -2,7 +2,9 @@ package hello.core.discount;
 
 import hello.core.member.entity.Member;
 import hello.core.member.repository.Grade;
+import org.springframework.stereotype.Component;
 
+@Component
 public class RateDiscountPolicy implements DiscountPolicy {
 
     private int discountPercent = 10;

--- a/Spring-Basic/core/src/main/java/hello/core/member/repository/MemoryMemberRepository.java
+++ b/Spring-Basic/core/src/main/java/hello/core/member/repository/MemoryMemberRepository.java
@@ -1,10 +1,12 @@
 package hello.core.member.repository;
 
 import hello.core.member.entity.Member;
+import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@Component
 public class MemoryMemberRepository implements MemberRepository {
 
     // TODO: 동시성 이슈때문에 ConcurrentHashMap을 사용해야 한다.

--- a/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
@@ -2,11 +2,15 @@ package hello.core.member.service;
 
 import hello.core.member.entity.Member;
 import hello.core.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
 
+    @Autowired  // ApplicationContext.getBean(MemberRepository.class)
     public MemberServiceImpl(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }

--- a/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
@@ -4,12 +4,16 @@ import hello.core.order.entity.Order;
 import hello.core.discount.DiscountPolicy;
 import hello.core.member.entity.Member;
 import hello.core.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class OrderServiceImpl implements OrderService {
 
     private final MemberRepository memberRepository;
     private final DiscountPolicy discountPolicy;
 
+    @Autowired
     public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;

--- a/Spring-Basic/core/src/test/java/hello/core/scan/AutoAppConfigTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/scan/AutoAppConfigTest.java
@@ -1,0 +1,24 @@
+package hello.core.scan;
+
+import hello.core.AutoAppConfig;
+import hello.core.member.service.MemberService;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AutoAppConfigTest {
+
+    @Test
+    void basicScan() {
+        // given
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AutoAppConfig.class);
+
+        // when
+        MemberService memberService = ac.getBean(MemberService.class);
+
+        // then
+        assertThat(memberService).isInstanceOf(MemberService.class);
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/scan/filter/ComponentFilterAppConfigTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/scan/filter/ComponentFilterAppConfigTest.java
@@ -1,0 +1,46 @@
+package hello.core.scan.filter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ComponentFilterAppConfigTest {
+
+    @Test
+    void filterScan() {
+        // given
+        ApplicationContext ac = new AnnotationConfigApplicationContext(ComponentFilterAppConfig.class);
+
+        // when
+        IncludeBean beanA = ac.getBean(IncludeBean.class);
+
+        // then
+        assertThat(beanA).isNotNull();
+
+        // when
+        // then
+        assertThatThrownBy(() -> ac.getBean(ExcludeBean.class))
+                .isInstanceOf(NoSuchBeanDefinitionException.class);
+    }
+
+    @Configuration
+    @ComponentScan(
+            includeFilters = @ComponentScan.Filter(
+                    type = FilterType.ANNOTATION,
+                    classes = MyIncludeComponent.class
+            ),
+            excludeFilters = @ComponentScan.Filter(
+                    type = FilterType.ANNOTATION,
+                    classes = MyExcludeComponent.class
+            )
+    )
+    static class ComponentFilterAppConfig {
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/scan/filter/ExcludeBean.java
+++ b/Spring-Basic/core/src/test/java/hello/core/scan/filter/ExcludeBean.java
@@ -1,0 +1,5 @@
+package hello.core.scan.filter;
+
+@MyExcludeComponent
+public class ExcludeBean {
+}

--- a/Spring-Basic/core/src/test/java/hello/core/scan/filter/IncludeBean.java
+++ b/Spring-Basic/core/src/test/java/hello/core/scan/filter/IncludeBean.java
@@ -1,0 +1,5 @@
+package hello.core.scan.filter;
+
+@MyIncludeComponent
+public class IncludeBean {
+}

--- a/Spring-Basic/core/src/test/java/hello/core/scan/filter/MyExcludeComponent.java
+++ b/Spring-Basic/core/src/test/java/hello/core/scan/filter/MyExcludeComponent.java
@@ -1,0 +1,10 @@
+package hello.core.scan.filter;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyExcludeComponent {
+
+}

--- a/Spring-Basic/core/src/test/java/hello/core/scan/filter/MyIncludeComponent.java
+++ b/Spring-Basic/core/src/test/java/hello/core/scan/filter/MyIncludeComponent.java
@@ -1,0 +1,10 @@
+package hello.core.scan.filter;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyIncludeComponent {
+
+}


### PR DESCRIPTION
# 컴포넌트 스캔

#### 스프링에서 제공하는 설정 정보 없이 자동으로 스프링 빈을 등록하는 기능

1. @ ComponentScan 어노테이션을 붙여준다.
- @ Component가 붙은 클래스를 스프링 빈으로 등록한다.
- excludeFilters 설정을 통해 기존 설정 정보들을 컴포넌트 스캔 대상에서 제외한다.

2. 스프링 빈으로 등록할 클래스에 @ Component 어노테이션을 붙여준다.
- 컴포넌트 스캔의 대상이 된다.

3. 의존성 주입이 필요한 클래스에는 생성자에 @ Autowired 어노테이션을 붙여준다.
- 스프링 컨테이너가 자동으로 해당 스프링 빈을 찾아서 주입한다.

>@ ComponentScan의 스프링 빈 이름 전략
>
> - 빈 이름 기본 전략: 클래스명을 사용하고, 맨 앞글자만 소문자로 사용한다.
> 	+ ex) MemberServiceImpl 클래스 memberServiceImpl
> - 빈 이름 직접 지정: 어노테이션 속성을 통해 이름을 부여한다.
>	+ ex) @ Component("memberServiceImpl")

## 탐색 위치

ComponentScan의 속성을 통해 컴포넌트 탐색 위치를 지정할 수 있다.

- basePackages: 탐색할 패키지의 시작 위치를 지정한다.
	+ 해당 패키지를 포함한 하위 모든 패키지를 탐색한다.
	
- basePackageClasses: 지정한 클래스의 패키지를 탐색 시작 위치로 지정한다.

- ***만약 지정하지 않으면 @ ComponentScan이 붙은 설정 정보 클래스의 패키지가 탐색 시작 위치가 된다.***
	+ 스프링 부트도 이 방법을 기본으로 제공한다.
	+ 스프링 부트 시작 정보인 @ SpringBootApplication 어노테이션이 @ ComponentScan이 들어있다.

## 기본 스캔 대상

#### 컴포넌트 스캔은 @ Component 어노테이션이 붙은 클래스를 대상으로 한다.

하지만, @ Component가 포함된 여러 어노테이션도 컴포넌트 스캔의 대상이 된다.

- @ Controlller : 스프링 MVC 컨트롤러에서 사용
- @ Service : 스프링 비즈니스 로직에서 사용
	+ 특별한 기능은 없지만, 비즈니스 계층을 인식하는데 도움을 준다.
- @ Repository : 스프링 데이터 접근 계층에서 사용
	+ 스프링 데이터 접근 계층으로, 데이터 계층의 예외를 스프링 예외로 변환해준다.
	+ 각각의 DB에서 발생하는 서로 다른 예외를 스프링에서 추상화한 예외로 변환해준다.
- @ Configuration : 스프링 설정 정보에서 사용
	+ 스프링 설정 정보를 인식하고, 스프링 빈이 싱글톤으로 유지하도록 추가 처리를 한다.

>어노테이션에는 상속관계가 없다.
>@ SpringBootApplication 어노테이션에 @ ComponentScan이 들어있다고 해서 @ ComponentScan 어노테이션을 인식하는 것은 
>자바에서 지원하는 기능이 아니라 스프링에서 지원하는 기능이다.

# 필터

ComponentScan 속성을 통해 필터를 설정할 수 있다.

- includeFilters : 컴포넌트 스캔 대상을 추가로 설정한다.
- excludeFilters : 컴포넌트 스캔에서 제외할 대상을 설정한다.

FilterType에는 여러 옵션이 있다.

- ANNOTATION: 기본값, 애노테이션을 인식해서 동작한다.
- ASSIGNABLE_TYPE: 지정한 타입과 자식 타입을 인식해서 동작한다.
- ASPECTJ: AspectJ 패턴 사용
	+org.example..*Service+
- REGEX: 정규 표현식
- CUSTOM: TypeFilter 이라는 인터페이스를 구현해서 처리한다.

## 중복 등록

### 자동 빈 등록 vs 자동 빈 등록

컴포넌트 스캔을 통해 자동으로 스프링 빈이 등록될 때, 같은 이름의 클래스(빈)가 있다면
ConflictingBeanDefinitionException 예외가 발생한다.

### 수동 빈 등록 vs 자동 빈 등록

- 수동 빈 등록이 우선권을 갖는다.
	+ 자동 등록된 빈을 오버라이딩 한다.
	+ 스프링에서는 로그를 남긴다.
- 최근 스프링 부트에서는 오류가 발생하도록 기본 값을 갖는다.