### PR TITLE
의존관계 자동 주입

### DIFF
--- a/Spring-Basic/core/build.gradle
+++ b/Spring-Basic/core/build.gradle
@@ -15,6 +15,9 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/Spring-Basic/core/src/main/java/hello/core/AppConfig.java
+++ b/Spring-Basic/core/src/main/java/hello/core/AppConfig.java
@@ -35,18 +35,13 @@ public class AppConfig {
     @Bean
     public MemberService memberService() {
         System.out.println("call AppConfig.memberService");
-        MemberServiceImpl memberService = new MemberServiceImpl();
-        memberService.setMemberRepository(memberRepository());
-        return memberService;
+        return new MemberServiceImpl(memberRepository());
     }
 
     @Bean
     public OrderService orderService() {
         System.out.println("call AppConfig.orderService");
-        OrderServiceImpl orderService = new OrderServiceImpl();
-        orderService.setMemberRepository(memberRepository());
-        orderService.setDiscountPolicy(discountPolicy());
-        return orderService;
+        return new OrderServiceImpl(memberRepository(), discountPolicy());
     }
 
     @Bean

--- a/Spring-Basic/core/src/main/java/hello/core/AppConfig.java
+++ b/Spring-Basic/core/src/main/java/hello/core/AppConfig.java
@@ -35,13 +35,17 @@ public class AppConfig {
     @Bean
     public MemberService memberService() {
         System.out.println("call AppConfig.memberService");
-        return new MemberServiceImpl(memberRepository());
+        MemberServiceImpl memberService = new MemberServiceImpl();
+        memberService.init(memberRepository());
+        return memberService;
     }
 
     @Bean
     public OrderService orderService() {
         System.out.println("call AppConfig.orderService");
-        return new OrderServiceImpl(memberRepository(), discountPolicy());
+        OrderServiceImpl orderService = new OrderServiceImpl();
+        orderService.init(memberRepository(), discountPolicy());
+        return orderService;
     }
 
     @Bean

--- a/Spring-Basic/core/src/main/java/hello/core/AppConfig.java
+++ b/Spring-Basic/core/src/main/java/hello/core/AppConfig.java
@@ -36,7 +36,7 @@ public class AppConfig {
     public MemberService memberService() {
         System.out.println("call AppConfig.memberService");
         MemberServiceImpl memberService = new MemberServiceImpl();
-        memberService.init(memberRepository());
+        memberService.setMemberRepository(memberRepository());
         return memberService;
     }
 
@@ -44,7 +44,8 @@ public class AppConfig {
     public OrderService orderService() {
         System.out.println("call AppConfig.orderService");
         OrderServiceImpl orderService = new OrderServiceImpl();
-        orderService.init(memberRepository(), discountPolicy());
+        orderService.setMemberRepository(memberRepository());
+        orderService.setDiscountPolicy(discountPolicy());
         return orderService;
     }
 

--- a/Spring-Basic/core/src/main/java/hello/core/annotation/MainDiscountPolicy.java
+++ b/Spring-Basic/core/src/main/java/hello/core/annotation/MainDiscountPolicy.java
@@ -1,0 +1,13 @@
+package hello.core.annotation;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@Qualifier("mainDiscountPolicy")
+public @interface MainDiscountPolicy {
+}

--- a/Spring-Basic/core/src/main/java/hello/core/discount/FixDiscountPolicy.java
+++ b/Spring-Basic/core/src/main/java/hello/core/discount/FixDiscountPolicy.java
@@ -2,7 +2,9 @@ package hello.core.discount;
 
 import hello.core.member.entity.Member;
 import hello.core.member.repository.Grade;
+import org.springframework.stereotype.Component;
 
+@Component
 public class FixDiscountPolicy implements DiscountPolicy {
 
     private int discountFixAmount = 1000;  // 1000원 할인

--- a/Spring-Basic/core/src/main/java/hello/core/discount/FixDiscountPolicy.java
+++ b/Spring-Basic/core/src/main/java/hello/core/discount/FixDiscountPolicy.java
@@ -2,11 +2,9 @@ package hello.core.discount;
 
 import hello.core.member.entity.Member;
 import hello.core.member.repository.Grade;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
-@Qualifier("fixDiscountPolicy")
 public class FixDiscountPolicy implements DiscountPolicy {
 
     private int discountFixAmount = 1000;  // 1000원 할인

--- a/Spring-Basic/core/src/main/java/hello/core/discount/FixDiscountPolicy.java
+++ b/Spring-Basic/core/src/main/java/hello/core/discount/FixDiscountPolicy.java
@@ -2,9 +2,11 @@ package hello.core.discount;
 
 import hello.core.member.entity.Member;
 import hello.core.member.repository.Grade;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
+@Qualifier("fixDiscountPolicy")
 public class FixDiscountPolicy implements DiscountPolicy {
 
     private int discountFixAmount = 1000;  // 1000원 할인

--- a/Spring-Basic/core/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/Spring-Basic/core/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -1,12 +1,12 @@
 package hello.core.discount;
 
+import hello.core.annotation.MainDiscountPolicy;
 import hello.core.member.entity.Member;
 import hello.core.member.repository.Grade;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
-@Qualifier("mainDiscountPolicy")
+@MainDiscountPolicy
 public class RateDiscountPolicy implements DiscountPolicy {
 
     private int discountPercent = 10;

--- a/Spring-Basic/core/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/Spring-Basic/core/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -2,9 +2,11 @@ package hello.core.discount;
 
 import hello.core.member.entity.Member;
 import hello.core.member.repository.Grade;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
+@Qualifier("mainDiscountPolicy")
 public class RateDiscountPolicy implements DiscountPolicy {
 
     private int discountPercent = 10;

--- a/Spring-Basic/core/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/Spring-Basic/core/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -1,12 +1,12 @@
 package hello.core.discount;
 
-import hello.core.annotation.MainDiscountPolicy;
 import hello.core.member.entity.Member;
 import hello.core.member.repository.Grade;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Component
-@MainDiscountPolicy
+@Primary
 public class RateDiscountPolicy implements DiscountPolicy {
 
     private int discountPercent = 10;

--- a/Spring-Basic/core/src/main/java/hello/core/member/entity/Member.java
+++ b/Spring-Basic/core/src/main/java/hello/core/member/entity/Member.java
@@ -1,28 +1,14 @@
 package hello.core.member.entity;
 
 import hello.core.member.repository.Grade;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
+@AllArgsConstructor
 public class Member {
 
     private Long id;
     private String name;
     private Grade grade;
-
-    public Member(Long id, String name, Grade grade) {
-        this.id = id;
-        this.name = name;
-        this.grade = grade;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public Grade getGrade() {
-        return grade;
-    }
 }

--- a/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
@@ -8,9 +8,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class MemberServiceImpl implements MemberService {
 
-    @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
     public void setMemberRepository(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }

--- a/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
@@ -2,16 +2,14 @@ package hello.core.member.service;
 
 import hello.core.member.entity.Member;
 import hello.core.member.repository.MemberRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MemberServiceImpl implements MemberService {
 
-    private MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
-    @Autowired
-    public void setMemberRepository(MemberRepository memberRepository) {
+    public MemberServiceImpl(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }
 

--- a/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
@@ -2,16 +2,14 @@ package hello.core.member.service;
 
 import hello.core.member.entity.Member;
 import hello.core.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
-
-    public MemberServiceImpl(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-    }
 
     @Override
     public void join(Member member) {

--- a/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
@@ -8,10 +8,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class MemberServiceImpl implements MemberService {
 
-    private final MemberRepository memberRepository;
+    private MemberRepository memberRepository;
 
-    @Autowired  // ApplicationContext.getBean(MemberRepository.class)
-    public MemberServiceImpl(MemberRepository memberRepository) {
+    @Autowired
+    public void init(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }
 

--- a/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/member/service/MemberServiceImpl.java
@@ -8,10 +8,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class MemberServiceImpl implements MemberService {
 
+    @Autowired
     private MemberRepository memberRepository;
 
-    @Autowired
-    public void init(MemberRepository memberRepository) {
+    public void setMemberRepository(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }
 

--- a/Spring-Basic/core/src/main/java/hello/core/order/entity/Order.java
+++ b/Spring-Basic/core/src/main/java/hello/core/order/entity/Order.java
@@ -1,5 +1,12 @@
 package hello.core.order.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@ToString
 public class Order {
 
     private Long memberId;
@@ -7,40 +14,7 @@ public class Order {
     private int itemPrice;
     private int discountPrice;
 
-    public Order(Long memberId, String itemName, int itemPrice, int discountPrice) {
-        this.memberId = memberId;
-        this.itemName = itemName;
-        this.itemPrice = itemPrice;
-        this.discountPrice = discountPrice;
-    }
-
     public int calculatePrice() {
         return itemPrice - discountPrice;
-    }
-
-    public Long getMemberId() {
-        return memberId;
-    }
-
-    public String getItemName() {
-        return itemName;
-    }
-
-    public int getItemPrice() {
-        return itemPrice;
-    }
-
-    public int getDiscountPrice() {
-        return discountPrice;
-    }
-
-    @Override
-    public String toString() {
-        return "Order{" +
-                "memberId=" + memberId +
-                ", itemName='" + itemName + '\'' +
-                ", itemPrice=" + itemPrice +
-                ", discountPrice=" + discountPrice +
-                '}';
     }
 }

--- a/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
@@ -1,20 +1,20 @@
 package hello.core.order.service;
 
-import hello.core.order.entity.Order;
 import hello.core.discount.DiscountPolicy;
 import hello.core.member.entity.Member;
 import hello.core.member.repository.MemberRepository;
+import hello.core.order.entity.Order;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OrderServiceImpl implements OrderService {
 
-    private final MemberRepository memberRepository;
-    private final DiscountPolicy discountPolicy;
+    private MemberRepository memberRepository;
+    private DiscountPolicy discountPolicy;
 
     @Autowired
-    public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
+    public void init(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;
     }

--- a/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
@@ -10,15 +10,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrderServiceImpl implements OrderService {
 
-    @Autowired
     private MemberRepository memberRepository;
-    @Autowired
     private DiscountPolicy discountPolicy;
 
+    @Autowired
     public void setMemberRepository(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }
 
+    @Autowired
     public void setDiscountPolicy(DiscountPolicy discountPolicy) {
         this.discountPolicy = discountPolicy;
     }

--- a/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
@@ -12,12 +12,12 @@ import org.springframework.stereotype.Component;
 public class OrderServiceImpl implements OrderService {
 
     private final MemberRepository memberRepository;
-    private final DiscountPolicy discountPolicy;
+    private final DiscountPolicy rateDiscountPolicy;
 
     @Override
     public Order createOrder(Long memberId, String itemName, int itemPrice) {
         Member member = memberRepository.findById(memberId);
-        int discountPrice = discountPolicy.discount(member, itemPrice);
+        int discountPrice = rateDiscountPolicy.discount(member, itemPrice);
 
         return new Order(memberId, itemName, itemPrice, discountPrice);
     }

--- a/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
@@ -1,10 +1,10 @@
 package hello.core.order.service;
 
+import hello.core.annotation.MainDiscountPolicy;
 import hello.core.discount.DiscountPolicy;
 import hello.core.member.entity.Member;
 import hello.core.member.repository.MemberRepository;
 import hello.core.order.entity.Order;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,7 +13,7 @@ public class OrderServiceImpl implements OrderService {
     private final MemberRepository memberRepository;
     private final DiscountPolicy discountPolicy;
 
-    public OrderServiceImpl(MemberRepository memberRepository, @Qualifier("mainDiscountPolicy") DiscountPolicy discountPolicy) {
+    public OrderServiceImpl(MemberRepository memberRepository, @MainDiscountPolicy DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;
     }

--- a/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
@@ -4,20 +4,24 @@ import hello.core.discount.DiscountPolicy;
 import hello.core.member.entity.Member;
 import hello.core.member.repository.MemberRepository;
 import hello.core.order.entity.Order;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService {
 
     private final MemberRepository memberRepository;
-    private final DiscountPolicy rateDiscountPolicy;
+    private final DiscountPolicy discountPolicy;
+
+    public OrderServiceImpl(MemberRepository memberRepository, @Qualifier("mainDiscountPolicy") DiscountPolicy discountPolicy) {
+        this.memberRepository = memberRepository;
+        this.discountPolicy = discountPolicy;
+    }
 
     @Override
     public Order createOrder(Long memberId, String itemName, int itemPrice) {
         Member member = memberRepository.findById(memberId);
-        int discountPrice = rateDiscountPolicy.discount(member, itemPrice);
+        int discountPrice = discountPolicy.discount(member, itemPrice);
 
         return new Order(memberId, itemName, itemPrice, discountPrice);
     }

--- a/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
@@ -4,22 +4,16 @@ import hello.core.discount.DiscountPolicy;
 import hello.core.member.entity.Member;
 import hello.core.member.repository.MemberRepository;
 import hello.core.order.entity.Order;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OrderServiceImpl implements OrderService {
 
-    private MemberRepository memberRepository;
-    private DiscountPolicy discountPolicy;
+    private final MemberRepository memberRepository;
+    private final DiscountPolicy discountPolicy;
 
-    @Autowired
-    public void setMemberRepository(MemberRepository memberRepository) {
+    public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
-    }
-
-    @Autowired
-    public void setDiscountPolicy(DiscountPolicy discountPolicy) {
         this.discountPolicy = discountPolicy;
     }
 

--- a/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
@@ -1,22 +1,18 @@
 package hello.core.order.service;
 
-import hello.core.annotation.MainDiscountPolicy;
 import hello.core.discount.DiscountPolicy;
 import hello.core.member.entity.Member;
 import hello.core.member.repository.MemberRepository;
 import hello.core.order.entity.Order;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService {
 
     private final MemberRepository memberRepository;
     private final DiscountPolicy discountPolicy;
-
-    public OrderServiceImpl(MemberRepository memberRepository, @MainDiscountPolicy DiscountPolicy discountPolicy) {
-        this.memberRepository = memberRepository;
-        this.discountPolicy = discountPolicy;
-    }
 
     @Override
     public Order createOrder(Long memberId, String itemName, int itemPrice) {

--- a/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
@@ -4,18 +4,15 @@ import hello.core.discount.DiscountPolicy;
 import hello.core.member.entity.Member;
 import hello.core.member.repository.MemberRepository;
 import hello.core.order.entity.Order;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService {
 
     private final MemberRepository memberRepository;
     private final DiscountPolicy discountPolicy;
-
-    public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
-        this.memberRepository = memberRepository;
-        this.discountPolicy = discountPolicy;
-    }
 
     @Override
     public Order createOrder(Long memberId, String itemName, int itemPrice) {

--- a/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
+++ b/Spring-Basic/core/src/main/java/hello/core/order/service/OrderServiceImpl.java
@@ -10,12 +10,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrderServiceImpl implements OrderService {
 
+    @Autowired
     private MemberRepository memberRepository;
+    @Autowired
     private DiscountPolicy discountPolicy;
 
-    @Autowired
-    public void init(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
+    public void setMemberRepository(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
+    }
+
+    public void setDiscountPolicy(DiscountPolicy discountPolicy) {
         this.discountPolicy = discountPolicy;
     }
 

--- a/Spring-Basic/core/src/test/java/hello/core/autowired/AllBeanTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/autowired/AllBeanTest.java
@@ -1,0 +1,58 @@
+package hello.core.autowired;
+
+import hello.core.AutoAppConfig;
+import hello.core.discount.DiscountPolicy;
+import hello.core.member.entity.Member;
+import hello.core.member.repository.Grade;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AllBeanTest {
+
+    @Test
+    void findAllBean() {
+        // given
+        Member member = new Member(1L, "member", Grade.VIP);
+
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AutoAppConfig.class, DiscountService.class);
+        DiscountService discountService = ac.getBean(DiscountService.class);
+
+        // when
+        int fixDiscountPrice = discountService.discount(member, 10000, "fixDiscountPolicy");
+
+        // then
+        assertThat(discountService).isInstanceOf(DiscountService.class);
+        assertThat(fixDiscountPrice).isEqualTo(1000);
+
+        // when
+        int rateDiscountPrice = discountService.discount(member, 20000, "rateDiscountPolicy");
+
+        // then
+        assertThat(discountService).isInstanceOf(DiscountService.class);
+        assertThat(rateDiscountPrice).isEqualTo(2000);
+    }
+
+    static class DiscountService {
+        private final Map<String, DiscountPolicy> policyMap;
+        private final List<DiscountPolicy> policies;
+
+        public DiscountService(Map<String, DiscountPolicy> policyMap, List<DiscountPolicy> policies) {
+            this.policyMap = policyMap;
+            this.policies = policies;
+
+            System.out.println("policyMap = " + policyMap);
+            System.out.println("policies = " + policies);
+        }
+
+        public int discount(Member member, int price, String discountCode) {
+            DiscountPolicy discountPolicy = policyMap.get(discountCode);
+            return discountPolicy.discount(member, price);
+        }
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/autowired/AutowiredTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/autowired/AutowiredTest.java
@@ -1,0 +1,44 @@
+package hello.core.autowired;
+
+import hello.core.member.entity.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.lang.Nullable;
+
+import java.util.Optional;
+
+public class AutowiredTest {
+
+
+    @Test
+    void autowiredOption() {
+        // when
+        ApplicationContext ac = new AnnotationConfigApplicationContext(TestBean.class);
+
+        // then
+        /* 출력결과
+        setNoBean2 = null
+        setNoBean3 = Optional.empty
+         */
+    }
+
+    static class TestBean{
+
+        @Autowired(required = false)
+        public void setNoBean1(Member member) {
+            System.out.println("setNoBean1 = " + member);
+        }
+
+        @Autowired
+        public void setNoBean2(@Nullable Member member) {
+            System.out.println("setNoBean2 = " + member);
+        }
+
+        @Autowired
+        public void setNoBean3(Optional<Member> member) {
+            System.out.println("setNoBean3 = " + member);
+        }
+    }
+}


### PR DESCRIPTION


# 의존관계 주입 방법

1. 일반 메서드 주입
2. 필드 주입
3. 수정자 주입(setter 주입)
4. 생성자 주입

## 일반 메서드 주입

일반 메서드를 통해 의존관계를 주입 받는 방법이다.

- 일반 메서드에 @ Autowired를 사용한다.
- 한번에 여러 필드를 주입받을 수 있다.

## 필드 주입

필드에 바로 주입하는 방법이다.

- 필드에 직접 @ Autowired를 사용한다.
- 코드가 간결하다.
    - 하지만 외부 변경이 불가능해서 테스트가 어렵다.
    - DI 프레임워크가 없으면 의존관계를 주입할 수 없다.
    - 테스트 코드나, 스프링 설정과 같이 특별한 용도로만 사용해야 한다.


## 수정자 주입

필드의 값을 변경하는 수정자 메서드를 통해 의존관계를 주입하는 방법이다.

- 자바빈 프로퍼티 규약의 수정자 메서드를 사용하는 방식인다.
    - 수정자는 관례상 setter라고 불린다.
- 일반 메서드 주입과 동일하게 수정자 메서드에 @ Autowired를 사용한다.
- 선택, 변경 가능성이 있는 의존관계에 사용한다.
- 수정자 주입을 사용하면 setter 메서드를 열어 두어야한다.
    - 생각지 못하게 수정자 메서드를 통해 의존관계가 변경될 수 있다.
    - 변경하면 안되는 메서드를 열어두는것은 좋을 설계 방법이 아니다.

## 생성자 주입

생성자를 통해 의존 관계를 주입 받는 방법이다.

- 생성자 호출 시점에 한번만 호출된다.
    - ***불변, 필수 의존관계에 사용된다.***
- 생성자가 1개라면 @ Autowired를 생략할 수 있다.

>생성자 주입을 권장한다.
>
>- 불변
>	- 대부분 의존관계 주입은 변경할 일이 없다. 오히려 대부분 의존관계는 종료 전까지 변하면 안된다.
>	- 수정자 주입은 setter 메서드를 열어두어야 하므로, 누군가 실수로 변경할 수 있다.
>	- 생성자 주입은 생성 시점에 한번만 호출되기 때문에 불변하게 설계할 수 있다.
>
>- 누락
>	- 의존관계 주입이 누락된 경우, 실제 실행해서 NullPointException이 발생하기 전까지 확인할 수 없다.
>	- 하지만, 생성자 주입을 사용하면 데이터를 누락 했을 때 ***컴파일 오류***가 발생한다.
>
>- final 키워드
>	- 생성자 주입을 사용하면 필드에 final 키워드를 사용할 수 있다.
>	- 생성자에 값이 누락되더라도, 컴파일 시점에 오류가 발생한다.

# @ Autowired 옵션 처리

@ Autowired의 required 옵션의 기본값은 true이기 때문에, 주입대상이 없으면 오류를 발생한다.

옵션 처리 방법

- @ Autowired(required=false): 자동 주입할 대상이 없으면 수정자 메서드 자체가 호출되지 않는다.
- org.springframework.lang.@Nullable: 자동 주입할 대상이 없으면 null이 주입된다.
- Optional<>: 자동 주입할 대상이 없으면 Optional.empty가 주입된다.

>@ Nullable, Optional은 스프링 전반에 걸쳐 지원된다.
>- 생성자 주입이나 특정 필드에만 사용할 수 있다.

# 조회 빈 2개 이상

#### @ Autowired는 타입(Type)으로 조회한다.

따라서, DiscountPolicy로 조회 시, 하위 타입인 FixDiscountPolicy와 RateDiscountPolicy 둘다 조회된다.
- NoUniqueBeanDefinitionException이 발생한다.
- 하위 타입으로 지정하면 DIP를 위배하고, 유연성이 떨어진다.

해결 방법

1. @ Autowired 필드 명 매칭
2. @ Qualifier
3. @ Primary

## @ Autowired 필드 명 매칭

1. @ Autowired는 타입 매칭을 시도한다.
2. 여러 빈이 있으면 필드 이름, 파라미터 이름으로 빈을 추가 매칭한다.

- 필드명을 rateDiscountPolicy로 변경하면
- DiscountPolicy 타입으로 매칭을 시도하고
    - 타입 매칭 결과 2개로 실패
- 파라미터 명으로 RateDiscountPolicy가 주입된다.

## @ Qualifier

@ Qualifier -> @ Qualifier 매칭 -> 빈 이름 매칭

추가 구분자를 붙여주는 방법이다

1. 빈 등록 시, @ Qualifier 이름을 붙여준다.
2. 의존관계 주입 시, 주입 받을 빈의 @ Qualifier 이름을 붙여준다.

>문자열을 통해 매번 @ Qualifier의 이름을 적는 행위는 실수를 유발하기 쉽고,
> 컴파일 시, 타입을 체크할 수 없다.
>
>스프링에서 제공하는 어노테이션을 모아서 사용하는 기능을 통해 어노테이션을 조합해서 사용할 수 있다.
>재사용하기 용이하다.
>컴파일 시, 오류를 체크할 수 있다.

## @ Primary

우선순위를 정하는 방법이다.

@ Primary가 붙은 빈이 우선권을 가진다.

1. RateDiscountPolicy 클래스에 @ Primary를 붙여준다.
2. 의존관계 주입 시, @Primary 어노테이션이 붙은 RateDiscountPolicy가 주입된다.

>@ Primary VS @ Qualifier
>
>- @ Qualifier를 사용하면 모든 코드에 @ Qualifier를 붙여주어야 한다.
>- @ Primary를 사용하면 부가적으로 작업을 더 할 필요가 없다.
>
>- @ Primary는 기본값 처럼 동작하고, @ Qualifier는 상세하게 동작하기 때문에
>- 우선순위는 @ Primary보다 @ Qualifier가 더 높다.

# 모든 빈 조회

List와 Map을 통해 같은 타입의 여러 빈들을 모두 사용할 수 있다.

## Map

- Map의 키에 스프링 빈 이름을 넣고, 값으로 조회된 스프링 빈을 담는다.
    - key(String): 빈 이름인 fixDiscountPolicy와 rateDiscountPolicy가 키가 된다.
    - value(DiscountPolicy): DiscountPolicy 타입으로 조회된 FixDiscountPolicy와 RateDiscountPolicy가 값이 된다.

## List

- DiscountPolicy 타입으로 조회된 모든 스프링 빈을 담는다.

>AnnotationConfigApplicationContext 생성자의 파라미터로 클래스를 넘기면
> 해당 클래스를 스프링 컨테이너에 직접 스프링 빈으로 등록한다.

# 스프링 빈 자동/수동 등록

#### 자동 기능을 기본으로 사용한다.

- 주입할 대상을 일일이 수동으로 등록해주는 과정을 번거롭다.
- 관리할 빈이 많아져서 설정 정보가 커지면 설정 정보를 관리하는 것 자체가 부담이 된다.
- 자동 빈 등록을 사용해도 충분히 OCP, DIP를 지킬 수 있다.

>수동 빈 등록을 사용하면 좋은 경우
>
>애플리케이션은 업무 로직과 기술 지원 로직으로 나눌 수 있다.
>
>- 업무 로직 빈: 보통 비지니스 요구사항을 개발할 때 추가되거나 변경되는 로직이다.
>	- 숫자도 많고, 어느정도 정형화된 패턴이 있다.
>	- 따라서, 문제가 어디서 발생했는지 명확하게 파악하기 쉽다.
>
>- 기술 지원 빈: 업무 로직을 지원하기 위한 하부 기술이나 공통 기술들이다.
>	- ex) DB 연결이나 공통 로그 처리 등
>	- 업무 로직 빈에 비해 그 수가 매우 적고, 보통 애플리케이션 전반에 걸쳐 광범위하게 영향을 미친다.
>	- 따라서, 잘 적용되고 있는지 조차 파악하기 어려운 경우가 많다.
>	- 이런 경우 수동 빈 등록을 통해 사용하여 명확하게 드러내는 것이 좋다.