### PR TITLE
빈 생명주기 콜백

### DIFF
--- a/Spring-Basic/core/src/test/java/hello/core/lifecycle/BeanLifeCycleTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/lifecycle/BeanLifeCycleTest.java
@@ -29,7 +29,7 @@ public class BeanLifeCycleTest {
     @Configuration
     static class LifeCycleConfig {
 
-        @Bean(initMethod = "init", destroyMethod = "close")
+        @Bean
         public NetworkClient networkClient() {
             NetworkClient networkClient = new NetworkClient();
             networkClient.setUrl("https://hello-spring.dev");

--- a/Spring-Basic/core/src/test/java/hello/core/lifecycle/BeanLifeCycleTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/lifecycle/BeanLifeCycleTest.java
@@ -20,9 +20,9 @@ public class BeanLifeCycleTest {
         // then
         /* 출력결과
         생성자 호출, url = null
-        connect: null
-        call: null / message = 초기화 연결 메시지
-        close: null
+        connect: https://hello-spring.dev
+        call: https://hello-spring.dev / message = 초기화 연결 메시지
+        close: https://hello-spring.dev
          */
     }
 

--- a/Spring-Basic/core/src/test/java/hello/core/lifecycle/BeanLifeCycleTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/lifecycle/BeanLifeCycleTest.java
@@ -1,0 +1,39 @@
+package hello.core.lifecycle;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+public class BeanLifeCycleTest {
+
+    @Test
+    public void lifeCycleTest() {
+        // given
+        ConfigurableApplicationContext ac = new AnnotationConfigApplicationContext(LifeCycleConfig.class);
+
+        // when
+        NetworkClient client = ac.getBean(NetworkClient.class);
+        ac.close();
+
+        // then
+        /* 출력결과
+        생성자 호출, url = null
+        connect: null
+        call: null / message = 초기화 연결 메시지
+        close: null
+         */
+    }
+
+    @Configuration
+    static class LifeCycleConfig {
+
+        @Bean
+        public NetworkClient networkClient() {
+            NetworkClient networkClient = new NetworkClient();
+            networkClient.setUrl("https://hello-spring.dev");
+            return networkClient;
+        }
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/lifecycle/BeanLifeCycleTest.java
+++ b/Spring-Basic/core/src/test/java/hello/core/lifecycle/BeanLifeCycleTest.java
@@ -29,7 +29,7 @@ public class BeanLifeCycleTest {
     @Configuration
     static class LifeCycleConfig {
 
-        @Bean
+        @Bean(initMethod = "init", destroyMethod = "close")
         public NetworkClient networkClient() {
             NetworkClient networkClient = new NetworkClient();
             networkClient.setUrl("https://hello-spring.dev");

--- a/Spring-Basic/core/src/test/java/hello/core/lifecycle/NetworkClient.java
+++ b/Spring-Basic/core/src/test/java/hello/core/lifecycle/NetworkClient.java
@@ -1,0 +1,30 @@
+package hello.core.lifecycle;
+
+public class NetworkClient {
+
+    private String url;
+
+    public NetworkClient() {
+        System.out.println("생성자 호출, url = " + url);
+        connect();
+        call("초기화 연결 메시지");
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    // 서비스 시작 시, 호출
+    public void connect() {
+        System.out.println("connect: " + url);
+    }
+
+    public void call(String message) {
+        System.out.println("call: " + url + " / message = " + message);
+    }
+
+    // 서비스 종료 시, 호출
+    public void disconnect() {
+        System.out.println("close: " + url);
+    }
+}

--- a/Spring-Basic/core/src/test/java/hello/core/lifecycle/NetworkClient.java
+++ b/Spring-Basic/core/src/test/java/hello/core/lifecycle/NetworkClient.java
@@ -1,13 +1,14 @@
 package hello.core.lifecycle;
 
-public class NetworkClient {
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+
+public class NetworkClient implements InitializingBean, DisposableBean {
 
     private String url;
 
     public NetworkClient() {
         System.out.println("생성자 호출, url = " + url);
-        connect();
-        call("초기화 연결 메시지");
     }
 
     public void setUrl(String url) {
@@ -26,5 +27,16 @@ public class NetworkClient {
     // 서비스 종료 시, 호출
     public void disconnect() {
         System.out.println("close: " + url);
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        connect();
+        call("초기화 연결 메시지");
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        disconnect();
     }
 }

--- a/Spring-Basic/core/src/test/java/hello/core/lifecycle/NetworkClient.java
+++ b/Spring-Basic/core/src/test/java/hello/core/lifecycle/NetworkClient.java
@@ -1,9 +1,6 @@
 package hello.core.lifecycle;
 
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.InitializingBean;
-
-public class NetworkClient implements InitializingBean, DisposableBean {
+public class NetworkClient {
 
     private String url;
 
@@ -29,14 +26,12 @@ public class NetworkClient implements InitializingBean, DisposableBean {
         System.out.println("close: " + url);
     }
 
-    @Override
-    public void afterPropertiesSet() throws Exception {
+    public void init() {
         connect();
         call("초기화 연결 메시지");
     }
 
-    @Override
-    public void destroy() throws Exception {
+    public void close() {
         disconnect();
     }
 }

--- a/Spring-Basic/core/src/test/java/hello/core/lifecycle/NetworkClient.java
+++ b/Spring-Basic/core/src/test/java/hello/core/lifecycle/NetworkClient.java
@@ -1,5 +1,8 @@
 package hello.core.lifecycle;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
 public class NetworkClient {
 
     private String url;
@@ -26,11 +29,13 @@ public class NetworkClient {
         System.out.println("close: " + url);
     }
 
+    @PostConstruct
     public void init() {
         connect();
         call("초기화 연결 메시지");
     }
 
+    @PreDestroy
     public void close() {
         disconnect();
     }


### PR DESCRIPTION


# 스프링 빈 생명주기 콜백

어플리케이션 시작 시점과 종료 시점에 작업을 진행해야하는 경우가 있다.
스프링은 콜백 메서드를 통해 작업을 진행할 수 있다. 

#### 스프링 빈 라이프사이클

-  객체 생성 -> 의존관계 주입 

#### 스프링 빈의 이벤트 라이프사이클

- 스프링 컨테이너 생성 -> 스프링 빈 생성 -> 의존관계 주입 -> 초기화 콜백 -> 사용 -> 소멸 전 콜백 -> 스프링 종료

>- 초기화 콜백: 빈이 생성되고, 빈의 의존관계 주입이 완료된 후 호출된디.
>	- 스프링은 의존관계 주입이 완료되면 콜백 메서드를 통해 초기화 시점을 알려주는 다양한 기능을 제공한다.
>
>- 소멸 전 콜백: 빈이 소멸되기 직전에 호출된다.
>	- 스프링은 스프링 컨테이너가 종료되기 직전에 소멸 콜백을 준다.

>객체의 생성과 초기화는 분리해야 한다.
>
>- 생성자는 필수 정보(파라미터)를 받고, 메모리를 할당해서 객체를 생성하는 책임을 갖는다.
>- 초기화는 이렇게 생성된 값들을 활용해서 무거운 동작을 수행한다.
>- 따라서, 무거운 초기화 작업을 생성자 안에서 하는 것 보다는 객체를 생성하는 부분과 초기화하는 부분을 명확하게 나누는 것이 유지보수 관점에서 좋다.

# 스프링 빈 생명주기 콜백 방법

1. 인터페이스(InitializingBean, DisposableBean)
2. 설정 정보에 초기화 메서드, 종료 메서드 지정
3. @ PostConstruct, @ PreDestroy

## InitializingBean, DisposableBean 인터페이스

인터페이스를 직접 구현받아서 사용하는 방법이다.

- InitializingBean: afterPropertiesSet() 메서드로 초기화를 지원한다.
- DisposableBean: destroy() 메서드로 소멸을 지원한다.

단점
- 스프링 전용 인터페이스기 때문에, 스프링 인용 인터페이스에 의존한다.
- 초기화, 소멸 메서드의 이름을 변경할 수 없다.
- 코드를 수정할 수 없는 외부 라이브러리에 적용할 수 없다.

## 설정 정보에 초기화 메서드, 종료 메서드 지정

설정 정보에 @ Bean의 속성을 활용하는 방법이다.

- initMethod: 초기화 메서드
- destroyMethod: 소멸 메서드
- 메서드 이름을 자유롭게 줄 수 있다.
- 스프링 빈이 스프링 코드에 의존하지 않는다.
- 설정 정보를 사용하기 떄문에, 외부 라이브러리에도 초기화, 종료 메서드를 적용할 수 있다.

>종료 메서드 추론
>
>- 대부분 종료 메서드의 이름은 close, shutdown이라는 이름을 갖는다.
>- @ Bean의 destroyMethod의 기본값은 (inferred)로 등록되어 있다.
>	- 이 추론 기능은 close, shutdown 이름의 메서드를 자동으로 호출한다.
>	- 따라서, 직접 스프링 빈으로 등록하면 종료 메서드는 따로 적어주지 않아도 동작한다.
>- 추론 기능을 사용하지 않으려면 destroyMethod=“”처럼 빈 공백을 지정해야 한다.

## @ PostConstruct, @ PreDestroy

어노테이션을 사용해 초기화와 종료를 실행하는 방법이다.

- 스프링에서 가장 권장하는 방법이다.
- 어노테이션만 붙이면 된다.
- Javax.annotation 패키지로, 스프링에 종속적인 기술이 아니라 JSR-250 자바 표준이다.
    - 따라서, 스프링이 아닌 다른 컨테이너에서도 동작한다.

단점

- 외부 라이브러리에는 적용하지 못한다.
    - 외부 라이브러리를 초기화, 종료 해야 하면 @ Bean의 속성을 활용해야 한다.