### PR TITLE
빈 스코프

### DIFF
--- a/Spring-Basic/build.gradle
+++ b/Spring-Basic/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'jakarta.inject:jakarta.inject-api:2.0.1'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/Spring-Basic/build.gradle
+++ b/Spring-Basic/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'jakarta.inject:jakarta.inject-api:2.0.1'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/Spring-Basic/src/main/java/hello/core/common/MyLogger.java
+++ b/Spring-Basic/src/main/java/hello/core/common/MyLogger.java
@@ -3,12 +3,13 @@ package hello.core.common;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
 
 @Component
-@Scope(value = "request")
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class MyLogger {
 
     private String uuid;

--- a/Spring-Basic/src/main/java/hello/core/common/MyLogger.java
+++ b/Spring-Basic/src/main/java/hello/core/common/MyLogger.java
@@ -1,0 +1,35 @@
+package hello.core.common;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@Scope(value = "request")
+public class MyLogger {
+
+    private String uuid;
+    private String requestURL;
+
+    public void setRequestURL(String requestURL) {
+        this.requestURL = requestURL;
+    }
+
+    public void log(String message) {
+        System.out.println("[" + uuid + "][" + requestURL + "] " + message);
+    }
+
+    @PostConstruct
+    public void init() {
+        uuid = UUID.randomUUID().toString();
+        System.out.println("[" + uuid + "] request scope bean create: " + this);
+    }
+
+    @PreDestroy
+    public void close() {
+        System.out.println("[" + uuid + "] request scope bean close: " + this);
+    }
+}

--- a/Spring-Basic/src/main/java/hello/core/web/controller/LogDemoController.java
+++ b/Spring-Basic/src/main/java/hello/core/web/controller/LogDemoController.java
@@ -4,7 +4,6 @@ import hello.core.common.MyLogger;
 import hello.core.web.service.LogDemoService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -14,12 +13,11 @@ import org.springframework.web.bind.annotation.ResponseBody;
 public class LogDemoController {
 
     private final LogDemoService logDemoService;
-    private final ObjectProvider<MyLogger> myLoggerProvider;
+    private final MyLogger myLogger;
 
     @RequestMapping("log-demo")
     @ResponseBody
     public String logDemo(HttpServletRequest request) {
-        MyLogger myLogger = myLoggerProvider.getObject();
         String requestURL = request.getRequestURL().toString();
         myLogger.setRequestURL(requestURL);
 

--- a/Spring-Basic/src/main/java/hello/core/web/controller/LogDemoController.java
+++ b/Spring-Basic/src/main/java/hello/core/web/controller/LogDemoController.java
@@ -1,0 +1,30 @@
+package hello.core.web.controller;
+
+import hello.core.common.MyLogger;
+import hello.core.web.service.LogDemoService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequiredArgsConstructor
+public class LogDemoController {
+
+    private final LogDemoService logDemoService;
+    private final ObjectProvider<MyLogger> myLoggerProvider;
+
+    @RequestMapping("log-demo")
+    @ResponseBody
+    public String logDemo(HttpServletRequest request) {
+        MyLogger myLogger = myLoggerProvider.getObject();
+        String requestURL = request.getRequestURL().toString();
+        myLogger.setRequestURL(requestURL);
+
+        myLogger.log("controller");
+        logDemoService.logic("ID");
+        return "OK";
+    }
+}

--- a/Spring-Basic/src/main/java/hello/core/web/service/LogDemoService.java
+++ b/Spring-Basic/src/main/java/hello/core/web/service/LogDemoService.java
@@ -1,0 +1,18 @@
+package hello.core.web.service;
+
+import hello.core.common.MyLogger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LogDemoService {
+
+    private final ObjectProvider<MyLogger> myLoggerProvider;
+
+    public void logic(String id) {
+        MyLogger myLogger = this.myLoggerProvider.getObject();
+        myLogger.log("service id = " + id);
+    }
+}

--- a/Spring-Basic/src/main/java/hello/core/web/service/LogDemoService.java
+++ b/Spring-Basic/src/main/java/hello/core/web/service/LogDemoService.java
@@ -2,17 +2,15 @@ package hello.core.web.service;
 
 import hello.core.common.MyLogger;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class LogDemoService {
 
-    private final ObjectProvider<MyLogger> myLoggerProvider;
+    private final MyLogger myLogger;
 
     public void logic(String id) {
-        MyLogger myLogger = this.myLoggerProvider.getObject();
         myLogger.log("service id = " + id);
     }
 }

--- a/Spring-Basic/src/test/java/hello/core/scope/PrototypeTest.java
+++ b/Spring-Basic/src/test/java/hello/core/scope/PrototypeTest.java
@@ -1,0 +1,44 @@
+package hello.core.scope;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Scope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PrototypeTest {
+
+    @Test
+    void prototypeBeanFind() {
+        // given
+        ConfigurableApplicationContext ac = new AnnotationConfigApplicationContext(PrototypeBean.class);
+
+        // when
+        PrototypeBean prototypeBean1 = ac.getBean(PrototypeBean.class);
+        PrototypeBean prototypeBean2 = ac.getBean(PrototypeBean.class);
+
+        // then
+        System.out.println("prototypeBean1 = " + prototypeBean1);
+        System.out.println("prototypeBean2 = " + prototypeBean2);
+
+        assertThat(prototypeBean1).isNotSameAs(prototypeBean2);
+
+        ac.close();
+    }
+
+    @Scope("prototype")
+    static class PrototypeBean {
+        @PostConstruct
+        public void init() {
+            System.out.println("PrototypeBean.init");
+        }
+
+        @PreDestroy
+        public void destroy() {
+            System.out.println("PrototypeBean.destroy");
+        }
+    }
+}

--- a/Spring-Basic/src/test/java/hello/core/scope/SingletonTest.java
+++ b/Spring-Basic/src/test/java/hello/core/scope/SingletonTest.java
@@ -1,0 +1,44 @@
+package hello.core.scope;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Scope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SingletonTest {
+
+    @Test
+    void singletonBeanFind() {
+        // given
+        ConfigurableApplicationContext ac = new AnnotationConfigApplicationContext(SingletonBean.class);
+
+        // when
+        SingletonBean singletonBean1 = ac.getBean(SingletonBean.class);
+        SingletonBean singletonBean2 = ac.getBean(SingletonBean.class);
+
+        // then
+        System.out.println("singletonBean1 = " + singletonBean1);
+        System.out.println("singletonBean2 = " + singletonBean2);
+
+        assertThat(singletonBean1).isSameAs(singletonBean2);
+
+        ac.close();
+    }
+
+    @Scope("singleton")
+    static class SingletonBean {
+        @PostConstruct
+        public void init() {
+            System.out.println("SingletonBean.init");
+        }
+
+        @PreDestroy
+        public void destroy() {
+            System.out.println("SingletonBean.destroy");
+        }
+    }
+}

--- a/Spring-Basic/src/test/java/hello/core/scope/SingletonWithPrototypeTest.java
+++ b/Spring-Basic/src/test/java/hello/core/scope/SingletonWithPrototypeTest.java
@@ -2,8 +2,8 @@ package hello.core.scope;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import jakarta.inject.Provider;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Scope;
@@ -53,14 +53,14 @@ public class SingletonWithPrototypeTest {
     }
 
     static class ClientBean {
-        private final ObjectProvider<PrototypeBean> prototypeBeanProvider;
+        private final Provider<PrototypeBean> prototypeBeanProvider;
 
-        public ClientBean(ObjectProvider<PrototypeBean> prototypeBeanProvider) {
+        public ClientBean(Provider<PrototypeBean> prototypeBeanProvider) {
             this.prototypeBeanProvider = prototypeBeanProvider;
         }
 
         public int logic() {
-            PrototypeBean prototypeBean = prototypeBeanProvider.getObject();
+            PrototypeBean prototypeBean = prototypeBeanProvider.get();
             prototypeBean.addCount();
             return prototypeBean.getCount();
         }

--- a/Spring-Basic/src/test/java/hello/core/scope/SingletonWithPrototypeTest.java
+++ b/Spring-Basic/src/test/java/hello/core/scope/SingletonWithPrototypeTest.java
@@ -1,0 +1,90 @@
+package hello.core.scope;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Scope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SingletonWithPrototypeTest {
+
+    @Test
+    void prototypeFind() {
+        // given
+        ApplicationContext ac = new AnnotationConfigApplicationContext(PrototypeBean.class);
+
+        // when
+        PrototypeBean prototypeBean1 = ac.getBean(PrototypeBean.class);
+        prototypeBean1.addCount();
+
+        // then
+        assertThat(prototypeBean1.getCount()).isEqualTo(1);
+
+        // when
+        PrototypeBean prototypeBean2 = ac.getBean(PrototypeBean.class);
+        prototypeBean2.addCount();
+
+        // then
+        assertThat(prototypeBean2.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    void singletonClientUsePrototype() {
+        // given
+        ApplicationContext ac = new AnnotationConfigApplicationContext(ClientBean.class, PrototypeBean.class);
+
+        // when
+        ClientBean clientBean1 = ac.getBean(ClientBean.class);
+        int count1 = clientBean1.logic();
+
+        // then
+        assertThat(count1).isEqualTo(1);
+
+        // when
+        ClientBean clientBean2 = ac.getBean(ClientBean.class);
+        int count2 = clientBean2.logic();
+
+        // then
+        assertThat(count2).isEqualTo(2);
+    }
+
+    static class ClientBean {
+        private final PrototypeBean prototypeBean;  // 생성시점에 주입
+
+        public ClientBean(PrototypeBean prototypeBean) {
+            this.prototypeBean = prototypeBean;
+        }
+
+        public int logic() {
+            prototypeBean.addCount();
+            return prototypeBean.getCount();
+        }
+    }
+
+    @Scope("prototype")
+    static class PrototypeBean {
+
+        private int count = 0;
+
+        public void addCount() {
+            count++;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        @PostConstruct
+        public void init() {
+            System.out.println("PrototypeBean.init " + this);
+        }
+
+        @PreDestroy
+        public void destroy() {
+            System.out.println("PrototypeBean.destroy");
+        }
+    }
+}

--- a/Spring-Basic/src/test/java/hello/core/scope/SingletonWithPrototypeTest.java
+++ b/Spring-Basic/src/test/java/hello/core/scope/SingletonWithPrototypeTest.java
@@ -3,6 +3,7 @@ package hello.core.scope;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Scope;
@@ -48,17 +49,18 @@ public class SingletonWithPrototypeTest {
         int count2 = clientBean2.logic();
 
         // then
-        assertThat(count2).isEqualTo(2);
+        assertThat(count2).isEqualTo(1);
     }
 
     static class ClientBean {
-        private final PrototypeBean prototypeBean;  // 생성시점에 주입
+        private final ObjectProvider<PrototypeBean> prototypeBeanProvider;
 
-        public ClientBean(PrototypeBean prototypeBean) {
-            this.prototypeBean = prototypeBean;
+        public ClientBean(ObjectProvider<PrototypeBean> prototypeBeanProvider) {
+            this.prototypeBeanProvider = prototypeBeanProvider;
         }
 
         public int logic() {
+            PrototypeBean prototypeBean = prototypeBeanProvider.getObject();
             prototypeBean.addCount();
             return prototypeBean.getCount();
         }


### PR DESCRIPTION
# 빈 스코프

스프링 빈이 존재할 수 있는 범위를 빈 스코프라 한다.
@ Scope를 통해 지정할 수 있다.

1. 싱글톤
- 기본 스코프
- 스프링 컨테이너의 시작 ~ 종료까지 유지되는 스코프
	
2. 프로토타입
- 스프링 컨테이너는 프로토타입 빈의 생성과 의존관계 주입까지만 관여하고, 더 이상 관리하지 않는 스코프
	
3. 웹 관련 스코프
- request
	+ 웹 요청이 들어오고 나갈때 까지 유지되는 스코프
	+ 각각의 HTTP 요청마다 별도의 빈 인스턴스가 생성되고, 관리된다.
- session:
	+ HTTP Session과 동일한 생명주기를 갖는 스코프
- appication: 
	+ 서블릿 컨텍스트(Servlet Context)와 동일한 생명주기를 갖는 스코프
- websocket
	+ 웹 소켓과 동일한 생명주기를 갖는 스코프
	
## 프로토타입 스코프

- 프로토타입 스코프를 스프링 컨테이너에서 조회하면 항상 새로운 인스턴스를 생성해서 반환한다.
- 스프링 컨테이너는 프로토타입 빈을 생성하고, 의존관계 주입, 초기화까지만 처리한다.
	- 따라서, 빈 초기화 메서드는 실행된다.
	- 생성된 프로토타입 빈은 스프링 컨테이너가 관리하지 않는다.

### 싱글톤 빈과 함께 사용 시, 문제점

싱글톤으로 관리되는 스프링 빈에서 프로토타입 빈을 주입받아 함께 사용할 때는 의도한 대로 작동하지 않는다.

1. 카운트하는 PrototypeBean 클래스의 스코프를 프로토타입으로 설정한다.
2. PrototypeBean을 주입받고, 싱글톤으로 관리되는 ClientBean 객체를 스프링 컨테이너에 등록한다.
3. 스프링 컨테이너로부터 ClientBean을 조회한다.
4. 카운트를 +1 한다.
	- 초기 카운트 필드의 값은 0이다.
	- 카운트 값은 1이 된다.
5. 스프링 컨테이너로부터 ClientBean을 다시 조회한다.
	- 싱글톤으로 항상 같은 ClientBean이 반환된다.
6. 카운트를 +1 한다.
	- ClientBean을 다시 조회했고, PrototypeBean은 프로토타입이기때문에 카운트 값은 1을 기대했지만 실제 카운트 값은 2이다.
	- ClientBean이 내부에 가지고 있는 프로토타입 빈은 이미 과거에 주입받은 빈이기 때문에, 새로 생성되는것이 아니다.
	- 따라서, 프로토타입의 빈을 싱글톤 빈에서 주입받아 사용하면 싱글톤 빈과 함께 계속해서 유지된다.
	
>여러 스프링 빈에서 같은 프로토타입 빈을 주입받으면, 주입 받는 시점마다 새로운 프로토타입 빈이 생성된다.
>따라서, 각각 다른 인스턴스의 프로토타입 빈을 주입받는다.

### 문제해결

1. 스프링 컨테이너에 새로 프로토타입 빈을 요청
	- ApplicationContext를 스프링 컨테이너로부터 주입받아 ApplicationContext.getBean(PrototypeBean.class) 메서드를 통해 새로운 프로토타입 빈을 생성하는 방법이다.
		- 의존관계를 외부에서 주입받는게 아니라 직접 의존관계를 찾는 의존관계 조회(DL: Dependency Lookup)라 한다.
	- 단점
		- ApplicationContext 전체를 주입받게 되면, 스프링 컨테이너에 종속적인 코드가 된다.
		- 단위 테스트도 어려워진다.

2. ObjectFactory, ObjectProvider
	- 지정한 빈을 스프링 컨테이너에서 찾아주는 DL 기능을 제공한다.
	- 단위 테스트가 쉽고, mock 코드를 만들기도 쉽다.
	- ObjectFactory: 기능이 단순하고, 별도의 라이브러리가 필요 없다.
	- ObjectProvider: ObjectFactory를 상속했고, 옵션, 스트림 등 편의 기능을 제공한다.
	- 하지만 스프링에 의존적이다.

3. ObjectFactory, ObjectProvider
	- Provider.get() 메서드 하나로 기능이 단순하다.
	- 단위 테스트가 쉽고, mock 코드를 만들기도 쉽다.
	- 자바 표준에서 제공하는 방법으로 스프링이 아닌 다른 컨테이너에서도 사용할 수 있다.
	- 하지만 별도의 라이브러리가 필요하다.

>자바 표준 vs 스프링 기능 사용
>
>자바 표준에서 제공하는 기능과 스프링에서 제공하는 기능이 유사한 경우가 많다.
>대부분 스프링이 더 다양하고 편리한 기능을 제공해주기 때문에, 특별히 다른 컨테이너를 사용할 일이 없다면 스프링이 제공하는 기능을 사용하면 된다.

## 웹 스코프

- 웹 환경에서 동작하는 스코프다.
- 프로토타입과 다르게 스코프의 종료 시점까지 스프링 컨테이너가 관리한다.

>spring-boot-starter-web 라이브러리를 추가하면 스프링 부트는 내장 톰켓 서버를 활용해서 웹 서버와 스프링을 함께 실행시킨다.
>
>스프링 부트는 웹 라이브러리가 없으면 AnnotationConfigApplicationContext를 기반으로 애플리케이션을 구동하고,
>웹 라이브러리가 추가되면 관련 추가 설정들과 환경들이 필요하기 때문 AnnotationCofigServletWebServerApplicationContext를 기반으로 구동한다.

### 싱글톤 빈에 request 스코프 빈 주입 시, 문제

1. 로그 출력을 위한 MyLogger 클래스를 만들고 @ Scope을 request로 지정한다.
2. LogDemoController와 LogDemoService에서 MyLogger 의존성을 주입받는다.
3. 애플리케이션을 실행한다.
4. 오류가 발생한다.
	- 스프링 애플리케이션이 실행하는 시점에 request 스코프 빈은 아직 생성되지 않았다.
	- HTTP 요청이 와야 생성하기 때문에, 주입할수 있는 객체가 없다.

>예제 코드 참고 사항
>
>- uuid를 통해 서로다른 HTTP 요청을 구분할 수 있다.
>- 실제 로그를 저장하는 부분은 컨트롤러가 아닌 공통 처리가 가능한 스프링 인터셉터나 서블릿 필터같은 곳을 활용하는 것이 좋다.
>- MyLogger를 서비스 계층에서도 스프링 컨테이너에서 조회한다.
>	- 웹과 관련된 정보가 웹과 관련없는 서비스 계층까지 넘어가는건 좋지 않다.
>	- 웹과 관련된 부분은 컨트롤러까지만 사용해야 한다.
>	- 서비스 계층은 웹 기술에 종속되지 않고, 순수하게 유지하는 것이 유지보수에 용이하다.

### 문제 해결

1. Provider 사용
	- MyLogger가 아닌 ObjectProvider<MyLogger>를 주입받는다.
	- MyLogger가 필요할 때, Provider를 통해 스프링 컨테이너에서 조회해서 사용한다.
	
2. 프록시 방식 사용
	- @ Scope의 proxyMode 속성을 ScopedProxyMode.TARGET_CLASS로 설정한다.
		- TARGET_CLASS: 적용 대상이 인터페이스가 아닌 클래스
		- INTERFACES: 적용 대상이 인터페이스
	- MyLogger의 가짜 프록시 클래스를 만든다.
		- 스프링에서 CGLIB 라이브러리를 통해 가짜 프록시 객체를 만든다.
		- ApplicationContext.getBean("myLogger", MyLogger.class)로 조회해도 프록시 객체가 조회된다.
	- HTTP 요청과 상관없이 가짜 프록시 객체를 다른 빈에 미리 주입한다.
	- HTTP 요청이 오면 내부에 진짜 스프링 빈을 요청한다.

특징
- 싱글톤 빈을 사용하듯 request 스코프 빈을 사용할 수 있다.
- **진짜 객체가 필요한 시점까지 지연처리 한다.**
- 어노테이션 설정 변경으로 원본 객체를 프록시 객체로 대체할 수 있다.
- 이는 다형성과 스프링 컨테이너가 가진 큰 강점이다.