### PR TITLE
서블릿, JSP, MVC 패턴

### DIFF
--- a/Spring-MVC-Part1/build.gradle
+++ b/Spring-MVC-Part1/build.gradle
@@ -21,6 +21,10 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.apache.tomcat.embed:tomcat-embed-jasper'
+    implementation 'jakarta.servlet:jakarta.servlet-api'
+    implementation 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api'
+    implementation 'org.glassfish.web:jakarta.servlet.jsp.jstl'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'

--- a/Spring-MVC-Part1/src/main/java/hello/servlet/domain/member/Member.java
+++ b/Spring-MVC-Part1/src/main/java/hello/servlet/domain/member/Member.java
@@ -1,0 +1,20 @@
+package hello.servlet.domain.member;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class Member {
+
+    private Long id;
+    private String username;
+    private int age;
+
+    public Member(String username, int age) {
+        this.username = username;
+        this.age = age;
+    }
+}

--- a/Spring-MVC-Part1/src/main/java/hello/servlet/domain/member/repository/MemberRepository.java
+++ b/Spring-MVC-Part1/src/main/java/hello/servlet/domain/member/repository/MemberRepository.java
@@ -1,0 +1,43 @@
+package hello.servlet.domain.member.repository;
+
+import hello.servlet.domain.member.Member;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MemberRepository {
+
+    // 동시성 문제가 고려되어 있지 않다.
+    // TODO: 실무에서는 ConcurrentHashMap, AtomicLong 사용 고려
+    private Map<Long, Member> store = new HashMap<>();
+    private long sequence = 0L;
+
+    private static final MemberRepository instance = new MemberRepository();
+
+    public static MemberRepository getInstance() {
+        return instance;
+    }
+
+    private MemberRepository() {
+    }
+
+    public Member save(Member member) {
+        member.setId(++sequence);
+        store.put(member.getId(), member);
+        return member;
+    }
+
+    public Member findById(Long id) {
+        return store.get(id);
+    }
+
+    public List<Member> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    public void clearStore() {
+        store.clear();
+    }
+}

--- a/Spring-MVC-Part1/src/main/java/hello/servlet/web/servlet/MemberFormServlet.java
+++ b/Spring-MVC-Part1/src/main/java/hello/servlet/web/servlet/MemberFormServlet.java
@@ -1,0 +1,36 @@
+package hello.servlet.web.servlet;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@WebServlet(name = "memberFormServlet", urlPatterns = "/servlet/members/new-form")
+public class MemberFormServlet extends HttpServlet {
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType("text/html");
+        response.setCharacterEncoding("UTF-8");
+
+        PrintWriter writer = response.getWriter();
+        writer.write("<!DOCTYPE html>\n" +
+                "<html>\n" +
+                "<head>\n" +
+                "    <meta charset=\"UTF-8\">\n" +
+                "    <title>Title</title>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<form action=\"/servlet/members/save\" method=\"post\">\n" +
+                "    username: <input type=\"text\" name=\"username\" />\n" +
+                "    age:      <input type=\"text\" name=\"age\" />\n" +
+                "    <button type=\"submit\">전송</button>\n" +
+                "</form>\n" +
+                "</body>\n" +
+                "</html>\n");
+    }
+}

--- a/Spring-MVC-Part1/src/main/java/hello/servlet/web/servlet/MemberListServlet.java
+++ b/Spring-MVC-Part1/src/main/java/hello/servlet/web/servlet/MemberListServlet.java
@@ -1,0 +1,54 @@
+package hello.servlet.web.servlet;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+
+@WebServlet(name = "memberListServlet", urlPatterns = "/servlet/members")
+public class MemberListServlet extends HttpServlet {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        List<Member> members = memberRepository.findAll();
+
+        response.setContentType("text/html");
+        response.setCharacterEncoding("UTF-8");
+
+        PrintWriter writer = response.getWriter();
+        writer.write("<html>\n" +
+                "<head>\n" +
+                "    <meta charset=\"UTF-8\">\n" +
+                "    <title>Title</title>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<a href=\"/index.html\">메인</a>\n" +
+                "<table>\n" +
+                "    <thead>\n" +
+                "        <th>id</th>\n" +
+                "        <th>username</th>\n" +
+                "        <th>age</th>\n" +
+                "    </thead>\n" +
+                "    <tbody>\n");
+        for (Member member : members) {
+            writer.write("    <tr>\n" +
+                    "        <td>" + member.getId() + "</td>\n" +
+                    "        <td>" + member.getUsername() + "</td>\n" +
+                    "        <td>" + member.getAge() + "</td>\n" +
+                    "    </tr>\n");
+        }
+        writer.write("    </tbody>\n" +
+                "</table>\n" +
+                "</body>\n" +
+                "</html>\n");
+    }
+}

--- a/Spring-MVC-Part1/src/main/java/hello/servlet/web/servlet/MemberSaveServlet.java
+++ b/Spring-MVC-Part1/src/main/java/hello/servlet/web/servlet/MemberSaveServlet.java
@@ -1,0 +1,46 @@
+package hello.servlet.web.servlet;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@WebServlet(name = "memberSaveServlet", urlPatterns = "/servlet/members/save")
+public class MemberSaveServlet extends HttpServlet {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String username = request.getParameter("username");
+        int age = Integer.parseInt(request.getParameter("age"));
+
+        Member member = new Member(username, age);
+        memberRepository.save(member);
+
+        response.setContentType("text/html");
+        response.setCharacterEncoding("UTF-8");
+
+        PrintWriter writer = response.getWriter();
+        writer.write("<html>\n" +
+                "<head>\n" +
+                "    <meta charset=\"UTF-8\">\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "성공\n" +
+                "<ul>\n" +
+                "    <li>id=" + member.getId() + "</li>\n" +
+                "    <li>username=" + member.getUsername() + "</li>\n" +
+                "    <li>age=" + member.getAge() + "</li>\n" +
+                "</ul>\n" +
+                "<a href=\"/index.html\">메인</a>\n" +
+                "</body>\n" +
+                "</html>");
+    }
+}

--- a/Spring-MVC-Part1/src/main/java/hello/servlet/web/servletmvc/MvcMemberFormServlet.java
+++ b/Spring-MVC-Part1/src/main/java/hello/servlet/web/servletmvc/MvcMemberFormServlet.java
@@ -1,0 +1,21 @@
+package hello.servlet.web.servletmvc;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebServlet(name = "mvcMemberFromServlet", urlPatterns = "/servlet-mvc/members/new-form")
+public class MvcMemberFormServlet extends HttpServlet {
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String viewPath = "/WEB-INF/views/new-form.jsp";
+        RequestDispatcher dispatcher = request.getRequestDispatcher(viewPath);
+        dispatcher.forward(request, response);
+    }
+}

--- a/Spring-MVC-Part1/src/main/java/hello/servlet/web/servletmvc/MvcMemberListServlet.java
+++ b/Spring-MVC-Part1/src/main/java/hello/servlet/web/servletmvc/MvcMemberListServlet.java
@@ -1,0 +1,30 @@
+package hello.servlet.web.servletmvc;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+@WebServlet(name = "mvcMemberListServlet", urlPatterns = "/servlet-mvc/members")
+public class MvcMemberListServlet extends HttpServlet {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        List<Member> members = memberRepository.findAll();
+
+        request.setAttribute("members", members);
+
+        String viewPath = "/WEB-INF/views/members.jsp";
+        RequestDispatcher dispatcher = request.getRequestDispatcher(viewPath);
+        dispatcher.forward(request, response);
+    }
+}

--- a/Spring-MVC-Part1/src/main/java/hello/servlet/web/servletmvc/MvcMemberSaveServlet.java
+++ b/Spring-MVC-Part1/src/main/java/hello/servlet/web/servletmvc/MvcMemberSaveServlet.java
@@ -1,0 +1,34 @@
+package hello.servlet.web.servletmvc;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebServlet(name = "mvcMemberSaveServlet", urlPatterns = "/servlet-mvc/members/save")
+public class MvcMemberSaveServlet extends HttpServlet {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String username = request.getParameter("username");
+        int age = Integer.parseInt(request.getParameter("age"));
+
+        Member member = new Member(username, age);
+        memberRepository.save(member);
+
+        // Model에 데이터 보관
+        request.setAttribute("member", member);
+
+        String viewPath = "/WEB-INF/views/save-result.jsp";
+        RequestDispatcher dispatcher = request.getRequestDispatcher(viewPath);
+        dispatcher.forward(request, response);
+    }
+}

--- a/Spring-MVC-Part1/src/main/webapp/WEB-INF/views/members.jsp
+++ b/Spring-MVC-Part1/src/main/webapp/WEB-INF/views/members.jsp
@@ -1,0 +1,26 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <title>Title</title>
+</head>
+<body>
+<a href="/index.html">메인</a>
+<table>
+    <thead>
+        <th>id</th>
+        <th>username</th>
+        <th>age</th>
+    </thead>
+    <tbody>
+    <c:forEach var="member" items="${members}">
+        <tr>
+            <td>${member.id}</td>
+            <td>${member.username}</td>
+            <td>${member.age}</td>
+        </tr>
+    </c:forEach>
+    </tbody>
+</table>
+</body>
+</html>

--- a/Spring-MVC-Part1/src/main/webapp/WEB-INF/views/new-form.jsp
+++ b/Spring-MVC-Part1/src/main/webapp/WEB-INF/views/new-form.jsp
@@ -1,0 +1,14 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <title>Title</title>
+</head>
+<body>
+<!-- 상대경로 사용, [현재 URL이 속한 계층 경로 + /save] -->
+<form action="save" method="post">
+    username: <input type="text" name="username" />
+    age:      <input type="text" name="age" />
+    <button type="submit">전송</button>
+</form>
+</body>
+</html>

--- a/Spring-MVC-Part1/src/main/webapp/WEB-INF/views/save-result.jsp
+++ b/Spring-MVC-Part1/src/main/webapp/WEB-INF/views/save-result.jsp
@@ -1,0 +1,15 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <title>Title</title>
+</head>
+<body>
+성공
+<ul>
+    <li>id=${member.id}</li>
+    <li>username=${member.username}</li>
+    <li>age=${member.age}</li>
+</ul>
+<a href="/index.html">메인</a>
+</body>
+</html>

--- a/Spring-MVC-Part1/src/main/webapp/index.html
+++ b/Spring-MVC-Part1/src/main/webapp/index.html
@@ -5,8 +5,79 @@
     <title>Title</title>
 </head>
 <body>
-  <ul>
+<ul>
     <li><a href="basic.html">서블릿 basic</a></li>
-  </ul>
+    <li>서블릿
+        <ul>
+            <li><a href="/servlet/members/new-form">회원가입</a></li>
+            <li><a href="/servlet/members">회원목록</a></li>
+        </ul>
+    </li>
+    <li>JSP
+        <ul>
+            <li><a href="/jsp/members/new-form.jsp">회원가입</a></li>
+            <li><a href="/jsp/members.jsp">회원목록</a></li>
+        </ul>
+    </li>
+    <li>서블릿 MVC
+        <ul>
+            <li><a href="/servlet-mvc/members/new-form">회원가입</a></li>
+            <li><a href="/servlet-mvc/members">회원목록</a></li>
+        </ul>
+    </li>
+    <li>FrontController - v1
+        <ul>
+            <li><a href="/front-controller/v1/members/new-form">회원가입</a></li>
+            <li><a href="/front-controller/v1/members">회원목록</a></li>
+        </ul>
+    </li>
+    <li>FrontController - v2
+        <ul> <li><a href="/front-controller/v2/members/new-form">회원가입</a></li>
+            <li><a href="/front-controller/v2/members">회원목록</a></li>
+        </ul>
+    </li>
+    <li>FrontController - v3
+        <ul>
+            <li><a href="/front-controller/v3/members/new-form">회원가입</a></li>
+            <li><a href="/front-controller/v3/members">회원목록</a></li>
+        </ul>
+    </li>
+    <li>FrontController - v4
+        <ul>
+            <li><a href="/front-controller/v4/members/new-form">회원가입</a></li>
+            <li><a href="/front-controller/v4/members">회원목록</a></li>
+        </ul>
+    </li>
+    <li>FrontController - v5 - v3
+        <ul>
+            <li><a href="/front-controller/v5/v3/members/new-form">회원가입</a></li>
+            <li><a href="/front-controller/v5/v3/members">회원목록</a></li>
+        </ul>
+    </li>
+    <li>FrontController - v5 - v4
+        <ul>
+            <li><a href="/front-controller/v5/v4/members/new-form">회원가입</a></li>
+            <li><a href="/front-controller/v5/v4/members">회원목록</a></li>
+        </ul>
+    </li>
+    <li>SpringMVC - v1
+        <ul>
+            <li><a href="/springmvc/v1/members/new-form">회원가입</a></li>
+            <li><a href="/springmvc/v1/members">회원목록</a></li>
+        </ul>
+    </li>
+    <li>SpringMVC - v2
+        <ul>
+            <li><a href="/springmvc/v2/members/new-form">회원가입</a></li>
+            <li><a href="/springmvc/v2/members">회원목록</a></li>
+        </ul>
+    </li>
+    <li>SpringMVC - v3
+        <ul>
+            <li><a href="/springmvc/v3/members/new-form">회원가입</a></li>
+            <li><a href="/springmvc/v3/members">회원목록</a></li>
+        </ul>
+    </li>
+</ul>
 </body>
 </html>

--- a/Spring-MVC-Part1/src/main/webapp/jsp/members.jsp
+++ b/Spring-MVC-Part1/src/main/webapp/jsp/members.jsp
@@ -1,0 +1,34 @@
+<%@ page import="hello.servlet.domain.member.repository.MemberRepository" %>
+<%@ page import="hello.servlet.domain.member.Member" %>
+<%@ page import="java.util.List" %>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%
+    MemberRepository memberRepository = MemberRepository.getInstance();
+    List<Member> members = memberRepository.findAll();
+%>
+<html>
+<head>
+    <title>Title</title>
+</head>
+<body>
+<a href="/index.html">메인</a>
+<table>
+    <thead>
+        <th>id</th>
+        <th>username</th>
+        <th>age</th>
+    </thead>
+    <tbody>
+    <%
+        for (Member member : members) {
+            out.write("    <tr>\n");
+            out.write("        <td>" + member.getId() + "</td>\n");
+            out.write("        <td>" + member.getUsername() + "</td>\n");
+            out.write("        <td>" + member.getAge() + "</td>\n");
+            out.write("    </tr>\n");
+        }
+    %>
+    </tbody>
+</table>
+</body>
+</html>

--- a/Spring-MVC-Part1/src/main/webapp/jsp/members/new-form.jsp
+++ b/Spring-MVC-Part1/src/main/webapp/jsp/members/new-form.jsp
@@ -1,0 +1,13 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <title>Title</title>
+</head>
+<body>
+<form action="/jsp/members/save.jsp" method="post">
+    username: <input type="text" name="username" />
+    age:      <input type="text" name="age" />
+    <button type="submit">전송</button>
+</form>
+</body>
+</html>

--- a/Spring-MVC-Part1/src/main/webapp/jsp/members/save.jsp
+++ b/Spring-MVC-Part1/src/main/webapp/jsp/members/save.jsp
@@ -1,0 +1,27 @@
+<%@ page import="hello.servlet.domain.member.repository.MemberRepository" %>
+<%@ page import="hello.servlet.domain.member.Member" %>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%
+    // request, response는 자동으로 사용 가능
+    MemberRepository memberRepository = MemberRepository.getInstance();
+
+    String username = request.getParameter("username");
+    int age = Integer.parseInt(request.getParameter("age"));
+
+    Member member = new Member(username, age);
+    memberRepository.save(member);
+%>
+<html>
+<head>
+    <title>Title</title>
+</head>
+<body>
+성공
+<ul>
+    <li>id=<%=member.getId()%></li>
+    <li>username=<%=member.getUsername()%></li>
+    <li>age=<%=member.getAge()%></li>
+</ul>
+<a href="/index.html">메인</a>
+</body>
+</html>

--- a/Spring-MVC-Part1/src/test/java/hello/servlet/domain/member/repository/MemberRepositoryTest.java
+++ b/Spring-MVC-Part1/src/test/java/hello/servlet/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,48 @@
+package hello.servlet.domain.member.repository;
+
+import hello.servlet.domain.member.Member;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberRepositoryTest {
+
+    MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @AfterEach
+    void afterEach() {
+        memberRepository.clearStore();
+    }
+
+    @Test
+    void save() {
+        // given
+        Member member = new Member("hello", 20);
+
+        // when
+        Member saveMember = memberRepository.save(member);
+
+        // then
+        Member findMember = memberRepository.findById(saveMember.getId());
+        assertThat(findMember).isEqualTo(saveMember);
+    }
+
+    @Test
+    void findAll() {
+        // given
+        Member member1 = new Member("member1", 20);
+        Member member2 = new Member("member2", 20);
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+
+        // when
+        List<Member> result = memberRepository.findAll();
+
+        // then
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result).contains(member1, member2);
+    }
+}


### PR DESCRIPTION
# 회원 관리 웹 애플리케이션 요구사항

#### 회원 정보

- 이름: username
- 나이: age

#### 기능 요구사항

- 회원 저장
- 회원 목록 조회

## 회원 저장소

1. 회원 도메인 Member 생성한다.

2. 회원 저장소 MemberRepository를 생성한다.
- 싱글톤 패턴을 적용한다.
- 단 하나의 객체만 생성해서 공유하도록 생성자를 private 접근자로 막는다.

# 서블릿

## 회원 등록 Form

단순 회원을 등록할 수 있는 HTML Form을 제공한다.

- content-type을 text/html로 지정한다.
- charset은 utf-8로 지정한다.
- HttpServletResponse.getWriter()를 통해 HTML From을 만들어서 응답한다.

## 회원 등록

회원을 저장하고, 결과 화면 HTML을 동적으로 만들어서 제공한다.

- HttpServletRequest.getParameter()를 통해 Form 입력 데이터를 조회한다.
	+ username, age값 조회
- 조회한 정보로 Member 인스턴스를 생성한다.
- Member를 MemberRepository를 통해 저장한다.
- 자바 코드로 Member를 사용하여 결과 화면 HTML을 동적으로 만들어서 응답한다.

## 회원 목록 조회

저장된 모든 회원 정보를 HTML로 돈적으로 만들어서 제공한다.

- MemberRepository.findAll()을 통해 모든 회원을 조회한다.
- 조회한 모든 회원을 for 루프틑 통해 동적으로 HTML을 만들어서 응답한다.

>서블릿을 활용하면 HTML을 동적으로 만들어서 응답할 수 있다.
>하지만 자바 코드로 HTML을 만들는 작업은 너무 복잡하고 비효율적이다.
>
>따라서 동적으로 변경해야하는 부분만 자바 코드를 넣을 수 있도록 템플릿 엔진이 등장했다.

# JSP

JSP를 사용하기 위해서는 라이브러리를 추가해야한다.

>스프링 부트 3.0부터는 여러 변경점이 있다.
>우선 Servlet 패키지가 javax.servlet -> jakarta.servlet으로 변경되었다.
>따라서, JSP와 JSTL을 사용하기 위해서는 아래 4개의 의존성을 주입받아야 한다.
>
>implementation 'org.apache.tomcat.embed:tomcat-embed-jasper'
>implementation 'jakarta.servlet:jakarta.servlet-api'
>implementation 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api'
>implementation 'org.glassfish.web:jakarta.servlet.jsp.jstl'

JSP는 최초 JSP가 호출되는 시점에 JSP 컨테이너에 의해 서블릿으로 변환된다.
따라서, MemberFormServlet과 비슷한 코드로 변환된다.

## 회원 등록 Form

JSP 문서 첫 줄은 `<%@ page contentType="text/html;charset=UTF-8" language="java" %>`로 시작한다.
JSP 문서라는 뜻이다.

- 회원 등록 Form JSP는 첫 줄을 제외하고는 HTML과 동일하다.

## 회원 등록

JSP 에는 자바 코드를 사용할 수 있다.

1. <%@ ~ %>: 자바의 import문과 같다.
2. <% ~ %>: 자바 코드를 입력할 수 있다.
3. <%= ~ %>: 자바 코드를 출력할 수 있다.

- JSP에서는 HTML을 중심으로하고, 자바 코드 부분이 추가된 형태이다.
- 동적으로 생성돼야하는 부분은 HTML 중간에 <%= ~ %>를 통해 자바 코드를 출력한다.

>JSP에서는 기본적으로 HttpServletRequest와 HttpServletResponse를 내장 객체로 제공한다.
>따라서, 별도의 작업 없이 request와 response를 직접 사용할 수 있다.

## 회원 목록 조회

- JSP 내 <% ~ %>를 통해 MemberRepository에서 회원 목록을 조회한다.
- 중간 HTML을 동적으로 생성해야 하는 부분은 자바 코드 for 루프를 통해 PrintWriter로 생성한다.

>JSP에서는 PrintWriter 또한 내장 객체로 제공한다.
>따라서, out을 통해 HTML, XML, JSON 등 텍스트를 출력할 수 있다.

# 서블릿과 JSP의 한계

1. 뷰(View)화면을 위한 HTML과 자바 코드가 섞여 지저분하고 복잡하다.
- 결과적으로 유지보수가 어렵다.

2. 서블릿의 경우 요청이 많을 경우, 각각 요청마다 새로운 스레드가 생성되므로 서버 부하가 커질 수 있다.

3. JSP의 경우 비즈니스 로직, MemberRepository 등 너무 많은 역할을 갖는다.

# MVC 패턴

#### 기존 문제점

1. 너무 많은 역할
- 하나의 서블릿이나 JSP는 비즈니스 로직과 뷰 렌더링까지 모두 처리하는 많은 역할을 갖는다.
- 단순 UI만 변경하더라도 비즈니스 로직이 함께 있는 파일을 수정해야 한다.

2. 변경의 라이프 사이클
- UI와 비즈니스 로직의 변경 라이프 사이클이 다르다.
	+ 대부분 UI와 비즈니스 로직의 수정이 각각 다른 시점에 발생할 확률이 높다.
	+ 또한, 서로에게 영향을 주지 않을 가능성이 높다.
- 변경 라이프 사이클이 다른 부분을 하나의 코드로 관리하는 것은 유지보수하기 어렵다.

3. 기능 특화
- JSP같은 뷰 템플릿은 화면 렌더링에 최적화 되어 있기 때문에 해당 업무만 담당하는 것이 효과적이다.

#### Model View Controller

- MVC 패턴은 컨트롤러(Controller)와 뷰(View)로 역할을 나눈 것을 말한다.
- 컨트롤러: HTTP 요청을 처리한다.
	+ 파라미터를 검증한다.
	+ 비즈니스 로직을 실행한다.
	+ 뷰에 전달할 결과 데이터를 모델에 담는다.
	
- 모델: 뷰에 출력할 데이터를 담아둔다.
	+ 따라서, 뷰는 비즈니스 로직이나 데이터 접근을 몰라도 된다.
	+ 단순하게 뷰에서 필요한 데이터를 모델에 담아서 전달한다.
	+ 뷰는 화면을 렌더링 하는 역할에 집중할 수 있다.
	
- 뷰: 모델에 담긴 데이터를 화면에 그리는 역할을한다.

![image](https://user-images.githubusercontent.com/50781066/231660991-325d8c99-ff54-4c73-9689-a4688f8e8704.png)

>일반적으로 비즈니스 로직은 서비스(Service) 계층을 별도로 만들어 처리한다.
>컨트롤러는 비즈니스 로직이 있는 서비스를 호출하는 역할을 담당한다.

## 회원 등록 Form

- 서블릿을 통해 컨트롤러로 HTTP 요청이 들어온다.
- service 메서드에서 RequestDispatcher.forward()를 통해 new-form.jsp로 요청을 전달한다.
	+ redirect는 실제 클라이언트에 응답이 나갔다가, 클라이언트가 redirect 경로로 다시 HTTP 요청을 한다.
		+ 따라서, 클라이언트가 인지할 수 있고, URL 경로도 변경된다.
	+ 하지만 forward 메서드는  서버 내부에서 일어나는 호출로, 클라이언트는 익식할 수 없다.

>/WEB-INF 경로 안에 JSP를 만들면 외부에서 직접 JSP를 호출할 수 없다.
>항상 컨트롤러를 통해 JSP를 호출해야한다.
>
>브라우저를 통해 `http://localhost:8080/WEB-INF/views/new-form.jsp`로 접근해도 404 상태를 응답받는다.

>new-form.jsp에서 form의 action경로를 '/'로 시작하는 절대 경로가 아닌 상대 경로로 설정했다.
>
>상대 경로로 설정하면 현재 URL이 속한 계층 경로에서 action 경로가 호출된다.
> /save가 아닌 /servlet-mvc/members/save가 호출된다.
>따라서, jsp를 다른 컨트롤러에서 계속 사용할 수 있다.
>
>상대 경로 단점 
>- 웹 애플리케이션이 배포된 디렉토리 구조에 의존적이다.
>- 웹 애플리케이션이 배포된 서버에서만 올바르게 작동한다.
>	+ 절대경로는 웹 애플리케이션이 배포된 서버의 호스트명과 포트번호를 기준으로 하기 때문에 다른 서버로 이동해도 올바르게 동작
>- 웹 애플리케이션의 구조가 변경될 때마다 모든 페이지에서 경로를 수정해야한다.
>
>따라서, 절대 경로 사용을 권장한다.

## 회원 등록

- HTTP 요청에서 username과 age를 조회한다.
- 조회한 정보로 Member 인스턴스를 만든다.
- Member를 MemberRepository를 통해 저장한다.
- HttpServletRequest를 Model로 사용하여 저장한 Member 데이터를 request.setAttribute()를 통해 객체에 보관한다.
- 뷰에서는 request.getAttribute()를 통해 데이터를 꺼내 사용한다.

>`<%= request.getAttribute("member")%>`로 모델에 저장된 객체를 꺼낼 수 있지만,
>JSP에서는  `${}`문법을 통해 request의 attribute에 담긴 데이터를 `${member.~}`처럼 편리하게 조회할 수 있다.

## 회원 목록 조회

- MemberRepository를 통해 모든 회원을 조회한다.
- request를 통해 List를 모델에 저장한다.
- JSTL을 사용해 동적으로 HTML을 생성한다.
	+ `<c:forEach>`를 기능을 사용하기 위해 `<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>`를 선언해야 한다.
	+ JSTL을 사용하지 않고 `<% ~ %>`를 활용하여 자바 코드 `out.write()`를 사용해도 된다.

# MVC 패턴의 한계

MVC 패턴을 통해 컨트롤러의 역할과 뷰를 렌더링 하는 역할을 명확하게 구분할 수 있다.
뷰는 단순하게 모델에서 필요한 데이터를 활용하여 화면을 그리는 역할에만 충실할 수 있다.
하지만, 컨트롤러는 중복이 많고, 필요하지 않은 코드들도 많다.

## 컨트롤러의 단점

1. forward 메서드 중복
- View로 이동하기위한 코드가 항상 중복 호출되어야 한다.

2. ViewPath의 내용 중복
- prefix: /WEB-INF/views/
- suffix: .jsp
- 만약 jsp가 아닌 다른 뷰 템플릿으로 변경한다면 전체 코드를 수정해야한다.

3. 사용하지 않는 코드
- HttpServletRequest와 HttpServletResponse는 사용할 때도 있고, 사용하지 않을 때도 있다.
- 특히 HttpServletResponse은 사용되지 않는다.
- HttpServletRequest와 HttpServletResponse를 사용하는 코드는 테스트 코드를 작성하기 어렵다.

4. 공통 처리가 어렵다.
- 공통 메서드 추출로 재사용할 수 있지만, 이 또한 해당 메서드를 항상 호출해야한다.
	+ 이것 또한 중복이다.
- 실수로 호출하지 않는다면 문제가 될 수 있다.

따라서, 컨트롤러를 호출 전에 공통기능을 처리하는 수문장 역할을 하는 ***프론트 컨트롤러(Front Controller) 패턴***을 도입해서 해결할 수 있다.