### PR TITLE
MVC 프레임워크 만들기

### DIFF
--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/ModelView.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/ModelView.java
@@ -1,0 +1,19 @@
+package hello.servlet.web.frontController;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class ModelView {
+
+    private String viewName;
+    private Map<String, Object> model = new HashMap<>();
+
+    public ModelView(String viewName) {
+        this.viewName = viewName;
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/MyView.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/MyView.java
@@ -1,0 +1,22 @@
+package hello.servlet.web.frontController;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class MyView {
+
+    private final String viewPath;
+
+    public MyView(String viewPath) {
+        this.viewPath = viewPath;
+    }
+
+    public void render(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        RequestDispatcher dispatcher = request.getRequestDispatcher(viewPath);
+        dispatcher.forward(request, response);
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/MyView.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/MyView.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.util.Map;
 
 public class MyView {
 
@@ -18,5 +19,14 @@ public class MyView {
     public void render(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         RequestDispatcher dispatcher = request.getRequestDispatcher(viewPath);
         dispatcher.forward(request, response);
+    }
+
+    public void render(Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        modelToRequestAttribute(model, request);
+        render(request, response);
+    }
+
+    private void modelToRequestAttribute(Map<String, Object> model, HttpServletRequest request) {
+        model.forEach(request::setAttribute);
     }
 }

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v1/ControllerV1.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v1/ControllerV1.java
@@ -1,0 +1,12 @@
+package hello.servlet.web.frontController.v1;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public interface ControllerV1 {
+
+    void process(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException;
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v1/FrontControllerServletV1.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v1/FrontControllerServletV1.java
@@ -1,0 +1,39 @@
+package hello.servlet.web.frontController.v1;
+
+import hello.servlet.web.frontController.v1.controller.MemberFormControllerV1;
+import hello.servlet.web.frontController.v1.controller.MemberListControllerV1;
+import hello.servlet.web.frontController.v1.controller.MemberSaveControllerV1;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@WebServlet(name = "frontControllerServletV1", urlPatterns = "/front-controller/v1/*")
+public class FrontControllerServletV1 extends HttpServlet {
+
+    private final Map<String, ControllerV1> controllerMap = new HashMap<>();
+
+    public FrontControllerServletV1() {
+        controllerMap.put("/front-controller/v1/members/new-form", new MemberFormControllerV1());
+        controllerMap.put("/front-controller/v1/members/save", new MemberSaveControllerV1());
+        controllerMap.put("/front-controller/v1/members", new MemberListControllerV1());
+    }
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String requestURI = request.getRequestURI();
+
+        ControllerV1 controller = controllerMap.get(requestURI);
+        if (controller == null) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        controller.process(request, response);
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v1/controller/MemberFormControllerV1.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v1/controller/MemberFormControllerV1.java
@@ -1,0 +1,19 @@
+package hello.servlet.web.frontController.v1.controller;
+
+import hello.servlet.web.frontController.v1.ControllerV1;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class MemberFormControllerV1 implements ControllerV1 {
+
+    @Override
+    public void process(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String viewPath = "/WEB-INF/views/new-form.jsp";
+        RequestDispatcher dispatcher = request.getRequestDispatcher(viewPath);
+        dispatcher.forward(request, response);
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v1/controller/MemberListControllerV1.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v1/controller/MemberListControllerV1.java
@@ -1,0 +1,28 @@
+package hello.servlet.web.frontController.v1.controller;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import hello.servlet.web.frontController.v1.ControllerV1;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+public class MemberListControllerV1 implements ControllerV1 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    public void process(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        List<Member> members = memberRepository.findAll();
+
+        request.setAttribute("members", members);
+
+        String viewPath = "/WEB-INF/views/members.jsp";
+        RequestDispatcher dispatcher = request.getRequestDispatcher(viewPath);
+        dispatcher.forward(request, response);
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v1/controller/MemberSaveControllerV1.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v1/controller/MemberSaveControllerV1.java
@@ -1,0 +1,32 @@
+package hello.servlet.web.frontController.v1.controller;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import hello.servlet.web.frontController.v1.ControllerV1;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class MemberSaveControllerV1 implements ControllerV1 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    public void process(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String username = request.getParameter("username");
+        int age = Integer.parseInt(request.getParameter("age"));
+
+        Member member = new Member(username, age);
+        memberRepository.save(member);
+
+        // Model에 데이터 보관
+        request.setAttribute("member", member);
+
+        String viewPath = "/WEB-INF/views/save-result.jsp";
+        RequestDispatcher dispatcher = request.getRequestDispatcher(viewPath);
+        dispatcher.forward(request, response);
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v2/ControllerV2.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v2/ControllerV2.java
@@ -1,0 +1,13 @@
+package hello.servlet.web.frontController.v2;
+
+import hello.servlet.web.frontController.MyView;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public interface ControllerV2 {
+
+    MyView process(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException;
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v2/FrontControllerServletV2.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v2/FrontControllerServletV2.java
@@ -1,0 +1,41 @@
+package hello.servlet.web.frontController.v2;
+
+import hello.servlet.web.frontController.MyView;
+import hello.servlet.web.frontController.v2.controller.MemberFormControllerV2;
+import hello.servlet.web.frontController.v2.controller.MemberListControllerV2;
+import hello.servlet.web.frontController.v2.controller.MemberSaveControllerV2;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@WebServlet(name = "frontControllerServletV2", urlPatterns = "/front-controller/v2/*")
+public class FrontControllerServletV2 extends HttpServlet {
+
+    private final Map<String, ControllerV2> controllerMap = new HashMap<>();
+
+    public FrontControllerServletV2() {
+        controllerMap.put("/front-controller/v2/members/new-form", new MemberFormControllerV2());
+        controllerMap.put("/front-controller/v2/members/save", new MemberSaveControllerV2());
+        controllerMap.put("/front-controller/v2/members", new MemberListControllerV2());
+    }
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String requestURI = request.getRequestURI();
+
+        ControllerV2 controller = controllerMap.get(requestURI);
+        if (controller == null) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        MyView view = controller.process(request, response);
+        view.render(request, response);
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v2/controller/MemberFormControllerV2.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v2/controller/MemberFormControllerV2.java
@@ -1,0 +1,17 @@
+package hello.servlet.web.frontController.v2.controller;
+
+import hello.servlet.web.frontController.MyView;
+import hello.servlet.web.frontController.v2.ControllerV2;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class MemberFormControllerV2 implements ControllerV2 {
+
+    @Override
+    public MyView process(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        return new MyView("/WEB-INF/views/new-form.jsp");
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v2/controller/MemberListControllerV2.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v2/controller/MemberListControllerV2.java
@@ -1,0 +1,24 @@
+package hello.servlet.web.frontController.v2.controller;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import hello.servlet.web.frontController.MyView;
+import hello.servlet.web.frontController.v2.ControllerV2;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+public class MemberListControllerV2 implements ControllerV2 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    public MyView process(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        List<Member> members = memberRepository.findAll();
+        request.setAttribute("members", members);
+        return new MyView("/WEB-INF/views/members.jsp");
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v2/controller/MemberSaveControllerV2.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v2/controller/MemberSaveControllerV2.java
@@ -1,0 +1,29 @@
+package hello.servlet.web.frontController.v2.controller;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import hello.servlet.web.frontController.MyView;
+import hello.servlet.web.frontController.v2.ControllerV2;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class MemberSaveControllerV2 implements ControllerV2 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    public MyView process(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String username = request.getParameter("username");
+        int age = Integer.parseInt(request.getParameter("age"));
+
+        Member member = new Member(username, age);
+        memberRepository.save(member);
+
+        request.setAttribute("member", member);
+
+        return new MyView("/WEB-INF/views/save-result.jsp");
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v3/ControllerV3.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v3/ControllerV3.java
@@ -1,0 +1,10 @@
+package hello.servlet.web.frontController.v3;
+
+import hello.servlet.web.frontController.ModelView;
+
+import java.util.Map;
+
+public interface ControllerV3 {
+
+    ModelView process(Map<String, String> paramMap);
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v3/FrontControllerServletV3.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v3/FrontControllerServletV3.java
@@ -1,0 +1,57 @@
+package hello.servlet.web.frontController.v3;
+
+import hello.servlet.web.frontController.ModelView;
+import hello.servlet.web.frontController.MyView;
+import hello.servlet.web.frontController.v3.controller.MemberFormControllerV3;
+import hello.servlet.web.frontController.v3.controller.MemberListControllerV3;
+import hello.servlet.web.frontController.v3.controller.MemberSaveControllerV3;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@WebServlet(name = "frontControllerServletV3", urlPatterns = "/front-controller/v3/*")
+public class FrontControllerServletV3 extends HttpServlet {
+
+    private final Map<String, ControllerV3> controllerMap = new HashMap<>();
+
+    public FrontControllerServletV3() {
+        controllerMap.put("/front-controller/v3/members/new-form", new MemberFormControllerV3());
+        controllerMap.put("/front-controller/v3/members/save", new MemberSaveControllerV3());
+        controllerMap.put("/front-controller/v3/members", new MemberListControllerV3());
+    }
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String requestURI = request.getRequestURI();
+
+        ControllerV3 controller = controllerMap.get(requestURI);
+        if (controller == null) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        Map<String, String> paramMap = createParamMap(request);
+
+        ModelView mv = controller.process(paramMap);
+        MyView view = viewResolver(mv.getViewName());
+
+        view.render(mv.getModel(), request, response);
+    }
+
+    private Map<String, String> createParamMap(HttpServletRequest request) {
+        Map<String, String> paramMap = new HashMap<>();
+        request.getParameterNames().asIterator()
+                .forEachRemaining(paramName -> paramMap.put(paramName, request.getParameter(paramName)));
+        return paramMap;
+    }
+
+    private MyView viewResolver(String viewName) {
+        return new MyView("/WEB-INF/views/" + viewName + ".jsp");
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v3/controller/MemberFormControllerV3.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v3/controller/MemberFormControllerV3.java
@@ -1,0 +1,14 @@
+package hello.servlet.web.frontController.v3.controller;
+
+import hello.servlet.web.frontController.ModelView;
+import hello.servlet.web.frontController.v3.ControllerV3;
+
+import java.util.Map;
+
+public class MemberFormControllerV3 implements ControllerV3 {
+
+    @Override
+    public ModelView process(Map<String, String> paramMap) {
+        return new ModelView("new-form");
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v3/controller/MemberListControllerV3.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v3/controller/MemberListControllerV3.java
@@ -1,0 +1,23 @@
+package hello.servlet.web.frontController.v3.controller;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import hello.servlet.web.frontController.ModelView;
+import hello.servlet.web.frontController.v3.ControllerV3;
+
+import java.util.List;
+import java.util.Map;
+
+public class MemberListControllerV3 implements ControllerV3 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    public ModelView process(Map<String, String> paramMap) {
+        List<Member> members = memberRepository.findAll();
+        ModelView mv = new ModelView("members");
+        mv.getModel().put("members", members);
+
+        return mv;
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v3/controller/MemberSaveControllerV3.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v3/controller/MemberSaveControllerV3.java
@@ -1,0 +1,26 @@
+package hello.servlet.web.frontController.v3.controller;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import hello.servlet.web.frontController.ModelView;
+import hello.servlet.web.frontController.v3.ControllerV3;
+
+import java.util.Map;
+
+public class MemberSaveControllerV3 implements ControllerV3 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    public ModelView process(Map<String, String> paramMap) {
+        String username = paramMap.get("username");
+        int age = Integer.parseInt(paramMap.get("age"));
+
+        Member member = new Member(username, age);
+        memberRepository.save(member);
+
+        ModelView mv = new ModelView("save-result");
+        mv.getModel().put("member", member);
+        return mv;
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v4/ControllerV4.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v4/ControllerV4.java
@@ -1,0 +1,13 @@
+package hello.servlet.web.frontController.v4;
+
+import java.util.Map;
+
+public interface ControllerV4 {
+
+    /**
+     * @param paramMap
+     * @param model
+     * @return viewName
+     */
+    String process(Map<String, String> paramMap, Map<String, Object> model);
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v4/FrontControllerServletV4.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v4/FrontControllerServletV4.java
@@ -1,0 +1,57 @@
+package hello.servlet.web.frontController.v4;
+
+import hello.servlet.web.frontController.MyView;
+import hello.servlet.web.frontController.v4.controller.MemberFormControllerV4;
+import hello.servlet.web.frontController.v4.controller.MemberListControllerV4;
+import hello.servlet.web.frontController.v4.controller.MemberSaveControllerV4;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@WebServlet(name = "frontControllerServletV4", urlPatterns = "/front-controller/v4/*")
+public class FrontControllerServletV4 extends HttpServlet {
+
+    private final Map<String, ControllerV4> controllerMap = new HashMap<>();
+
+    public FrontControllerServletV4() {
+        controllerMap.put("/front-controller/v4/members/new-form", new MemberFormControllerV4());
+        controllerMap.put("/front-controller/v4/members/save", new MemberSaveControllerV4());
+        controllerMap.put("/front-controller/v4/members", new MemberListControllerV4());
+    }
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String requestURI = request.getRequestURI();
+
+        ControllerV4 controller = controllerMap.get(requestURI);
+        if (controller == null) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        Map<String, String> paramMap = createParamMap(request);
+        Map<String, Object> model = new HashMap<>();
+
+        String viewName = controller.process(paramMap, model);
+
+        MyView myView = viewResolver(viewName);
+        myView.render(model, request, response);
+    }
+
+    private Map<String, String> createParamMap(HttpServletRequest request) {
+        Map<String, String> paramMap = new HashMap<>();
+        request.getParameterNames().asIterator()
+                .forEachRemaining(paramName -> paramMap.put(paramName, request.getParameter(paramName)));
+        return paramMap;
+    }
+
+    private MyView viewResolver(String viewName) {
+        return new MyView("/WEB-INF/views/" + viewName + ".jsp");
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v4/controller/MemberFormControllerV4.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v4/controller/MemberFormControllerV4.java
@@ -1,0 +1,13 @@
+package hello.servlet.web.frontController.v4.controller;
+
+import hello.servlet.web.frontController.v4.ControllerV4;
+
+import java.util.Map;
+
+public class MemberFormControllerV4 implements ControllerV4 {
+
+    @Override
+    public String process(Map<String, String> paramMap, Map<String, Object> model) {
+        return "new-form";
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v4/controller/MemberListControllerV4.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v4/controller/MemberListControllerV4.java
@@ -1,0 +1,21 @@
+package hello.servlet.web.frontController.v4.controller;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import hello.servlet.web.frontController.v4.ControllerV4;
+
+import java.util.List;
+import java.util.Map;
+
+public class MemberListControllerV4 implements ControllerV4 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    public String process(Map<String, String> paramMap, Map<String, Object> model) {
+        List<Member> members = memberRepository.findAll();
+
+        model.put("members", members);
+        return "members";
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v4/controller/MemberSaveControllerV4.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v4/controller/MemberSaveControllerV4.java
@@ -1,0 +1,24 @@
+package hello.servlet.web.frontController.v4.controller;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import hello.servlet.web.frontController.v4.ControllerV4;
+
+import java.util.Map;
+
+public class MemberSaveControllerV4 implements ControllerV4 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    public String process(Map<String, String> paramMap, Map<String, Object> model) {
+        String username = paramMap.get("username");
+        int age = Integer.parseInt(paramMap.get("age"));
+
+        Member member = new Member(username, age);
+        memberRepository.save(member);
+
+        model.put("member", member);
+        return "save-result";
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/FrontControllerServletV5.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/FrontControllerServletV5.java
@@ -5,7 +5,11 @@ import hello.servlet.web.frontController.MyView;
 import hello.servlet.web.frontController.v3.controller.MemberFormControllerV3;
 import hello.servlet.web.frontController.v3.controller.MemberListControllerV3;
 import hello.servlet.web.frontController.v3.controller.MemberSaveControllerV3;
+import hello.servlet.web.frontController.v4.controller.MemberFormControllerV4;
+import hello.servlet.web.frontController.v4.controller.MemberListControllerV4;
+import hello.servlet.web.frontController.v4.controller.MemberSaveControllerV4;
 import hello.servlet.web.frontController.v5.adapter.ControllerV3HandlerAdapter;
+import hello.servlet.web.frontController.v5.adapter.ControllerV4HandlerAdapter;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -50,10 +54,15 @@ public class FrontControllerServletV5 extends HttpServlet {
         handlerMappingMap.put("/front-controller/v5/v3/members/new-form", new MemberFormControllerV3());
         handlerMappingMap.put("/front-controller/v5/v3/members/save", new MemberSaveControllerV3());
         handlerMappingMap.put("/front-controller/v5/v3/members", new MemberListControllerV3());
+
+        handlerMappingMap.put("/front-controller/v5/v4/members/new-form", new MemberFormControllerV4());
+        handlerMappingMap.put("/front-controller/v5/v4/members/save", new MemberSaveControllerV4());
+        handlerMappingMap.put("/front-controller/v5/v4/members", new MemberListControllerV4());
     }
 
     private void initHandlerAdapters() {
         handlerAdapters.add(new ControllerV3HandlerAdapter());
+        handlerAdapters.add(new ControllerV4HandlerAdapter());
     }
 
     private Object getHandler(HttpServletRequest request) {

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/FrontControllerServletV5.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/FrontControllerServletV5.java
@@ -1,0 +1,77 @@
+package hello.servlet.web.frontController.v5;
+
+import hello.servlet.web.frontController.ModelView;
+import hello.servlet.web.frontController.MyView;
+import hello.servlet.web.frontController.v3.controller.MemberFormControllerV3;
+import hello.servlet.web.frontController.v3.controller.MemberListControllerV3;
+import hello.servlet.web.frontController.v3.controller.MemberSaveControllerV3;
+import hello.servlet.web.frontController.v5.adapter.ControllerV3HandlerAdapter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@WebServlet(name = "frontControllerServletV5", urlPatterns = "/front-controller/v5/*")
+public class FrontControllerServletV5 extends HttpServlet {
+
+    private final Map<String, Object> handlerMappingMap = new HashMap<>();
+    private final List<MyHandlerAdapter> handlerAdapters = new ArrayList<>();
+
+    public FrontControllerServletV5() {
+        initHandlerMappingMap();
+        initHandlerAdapters();
+    }
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        Object handler = getHandler(request);
+
+        if (handler == null) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        MyHandlerAdapter adapter = getHandlerAdapter(handler);
+
+        ModelView mv = adapter.handle(request, response, handler);
+        MyView view = viewResolver(mv.getViewName());
+
+        view.render(mv.getModel(), request, response);
+    }
+
+    private void initHandlerMappingMap() {
+        handlerMappingMap.put("/front-controller/v5/v3/members/new-form", new MemberFormControllerV3());
+        handlerMappingMap.put("/front-controller/v5/v3/members/save", new MemberSaveControllerV3());
+        handlerMappingMap.put("/front-controller/v5/v3/members", new MemberListControllerV3());
+    }
+
+    private void initHandlerAdapters() {
+        handlerAdapters.add(new ControllerV3HandlerAdapter());
+    }
+
+    private Object getHandler(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        return handlerMappingMap.get(requestURI);
+    }
+
+    private MyHandlerAdapter getHandlerAdapter(Object handler) {
+        for (MyHandlerAdapter adapter : handlerAdapters) {
+            if (adapter.supports(handler)) {
+                return adapter;
+            }
+        }
+
+        throw new IllegalArgumentException("Handler Adapter를 찾을 수 없습니다. handler: " + handler);
+    }
+
+    private MyView viewResolver(String viewName) {
+        return new MyView("/WEB-INF/views/" + viewName + ".jsp");
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/FrontControllerServletV5.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/FrontControllerServletV5.java
@@ -2,14 +2,7 @@ package hello.servlet.web.frontController.v5;
 
 import hello.servlet.web.frontController.ModelView;
 import hello.servlet.web.frontController.MyView;
-import hello.servlet.web.frontController.v3.controller.MemberFormControllerV3;
-import hello.servlet.web.frontController.v3.controller.MemberListControllerV3;
-import hello.servlet.web.frontController.v3.controller.MemberSaveControllerV3;
-import hello.servlet.web.frontController.v4.controller.MemberFormControllerV4;
-import hello.servlet.web.frontController.v4.controller.MemberListControllerV4;
-import hello.servlet.web.frontController.v4.controller.MemberSaveControllerV4;
-import hello.servlet.web.frontController.v5.adapter.ControllerV3HandlerAdapter;
-import hello.servlet.web.frontController.v5.adapter.ControllerV4HandlerAdapter;
+import hello.servlet.web.frontController.v5.adapter.HandlerAdapterFactory;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -17,67 +10,30 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 @WebServlet(name = "frontControllerServletV5", urlPatterns = "/front-controller/v5/*")
 public class FrontControllerServletV5 extends HttpServlet {
 
-    private final Map<String, Object> handlerMappingMap = new HashMap<>();
-    private final List<MyHandlerAdapter> handlerAdapters = new ArrayList<>();
+    private final HandlerAdapterFactory handlerAdapterFactory;
 
     public FrontControllerServletV5() {
-        initHandlerMappingMap();
-        initHandlerAdapters();
+        handlerAdapterFactory = new HandlerAdapterFactory();
     }
 
     @Override
     protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        Object handler = getHandler(request);
+        try {
+            Object handler = handlerAdapterFactory.getHandler(request.getRequestURI());
+            MyHandlerAdapter adapter = handlerAdapterFactory.getAdapter(handler);
 
-        if (handler == null) {
+            ModelView mv = adapter.handle(request, response, handler);
+            MyView view = viewResolver(mv.getViewName());
+
+            view.render(mv.getModel(), request, response);
+        } catch (IllegalArgumentException e) {
+            System.out.println(e.getMessage());
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            return;
         }
-
-        MyHandlerAdapter adapter = getHandlerAdapter(handler);
-
-        ModelView mv = adapter.handle(request, response, handler);
-        MyView view = viewResolver(mv.getViewName());
-
-        view.render(mv.getModel(), request, response);
-    }
-
-    private void initHandlerMappingMap() {
-        handlerMappingMap.put("/front-controller/v5/v3/members/new-form", new MemberFormControllerV3());
-        handlerMappingMap.put("/front-controller/v5/v3/members/save", new MemberSaveControllerV3());
-        handlerMappingMap.put("/front-controller/v5/v3/members", new MemberListControllerV3());
-
-        handlerMappingMap.put("/front-controller/v5/v4/members/new-form", new MemberFormControllerV4());
-        handlerMappingMap.put("/front-controller/v5/v4/members/save", new MemberSaveControllerV4());
-        handlerMappingMap.put("/front-controller/v5/v4/members", new MemberListControllerV4());
-    }
-
-    private void initHandlerAdapters() {
-        handlerAdapters.add(new ControllerV3HandlerAdapter());
-        handlerAdapters.add(new ControllerV4HandlerAdapter());
-    }
-
-    private Object getHandler(HttpServletRequest request) {
-        String requestURI = request.getRequestURI();
-        return handlerMappingMap.get(requestURI);
-    }
-
-    private MyHandlerAdapter getHandlerAdapter(Object handler) {
-        for (MyHandlerAdapter adapter : handlerAdapters) {
-            if (adapter.supports(handler)) {
-                return adapter;
-            }
-        }
-
-        throw new IllegalArgumentException("Handler Adapter를 찾을 수 없습니다. handler: " + handler);
     }
 
     private MyView viewResolver(String viewName) {

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/MyHandlerAdapter.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/MyHandlerAdapter.java
@@ -1,0 +1,15 @@
+package hello.servlet.web.frontController.v5;
+
+import hello.servlet.web.frontController.ModelView;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public interface MyHandlerAdapter {
+
+    boolean supports(Object handler);
+
+    ModelView handle(HttpServletRequest request, HttpServletResponse response, Object handler) throws ServletException, IOException;
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/adapter/ControllerV3HandlerAdapter.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/adapter/ControllerV3HandlerAdapter.java
@@ -1,0 +1,36 @@
+package hello.servlet.web.frontController.v5.adapter;
+
+import hello.servlet.web.frontController.ModelView;
+import hello.servlet.web.frontController.v3.ControllerV3;
+import hello.servlet.web.frontController.v5.MyHandlerAdapter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ControllerV3HandlerAdapter implements MyHandlerAdapter {
+
+    @Override
+    public boolean supports(Object handler) {
+        return (handler instanceof ControllerV3);
+    }
+
+    @Override
+    public ModelView handle(HttpServletRequest request, HttpServletResponse response, Object handler) throws ServletException, IOException {
+        ControllerV3 controller = (ControllerV3) handler;
+
+        Map<String, String> paramMap = createParamMap(request);
+        return controller.process(paramMap);
+    }
+
+    private Map<String, String> createParamMap(HttpServletRequest request) {
+        Map<String, String> paramMap = new HashMap<>();
+        request.getParameterNames().asIterator()
+                .forEachRemaining(paramName -> paramMap.put(paramName, request.getParameter(paramName)));
+
+        return paramMap;
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/adapter/ControllerV4HandlerAdapter.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/adapter/ControllerV4HandlerAdapter.java
@@ -1,0 +1,39 @@
+package hello.servlet.web.frontController.v5.adapter;
+
+import hello.servlet.web.frontController.ModelView;
+import hello.servlet.web.frontController.v4.ControllerV4;
+import hello.servlet.web.frontController.v5.MyHandlerAdapter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ControllerV4HandlerAdapter implements MyHandlerAdapter {
+
+    @Override
+    public boolean supports(Object handler) {
+        return (handler instanceof ControllerV4);
+    }
+
+    @Override
+    public ModelView handle(HttpServletRequest request, HttpServletResponse response, Object handler) throws ServletException, IOException {
+        ControllerV4 controller = (ControllerV4) handler;
+
+        Map<String, String> paramMap = createParamMap(request);
+        Map<String, Object> model = new HashMap<>();
+
+        String viewName = controller.process(paramMap, model);
+        return new ModelView(viewName, model);
+    }
+
+    private Map<String, String> createParamMap(HttpServletRequest request) {
+        Map<String, String> paramMap = new HashMap<>();
+        request.getParameterNames().asIterator()
+                .forEachRemaining(paramName -> paramMap.put(paramName, request.getParameter(paramName)));
+
+        return paramMap;
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/adapter/HandlerAdapterFactory.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/frontController/v5/adapter/HandlerAdapterFactory.java
@@ -1,0 +1,61 @@
+package hello.servlet.web.frontController.v5.adapter;
+
+import hello.servlet.web.frontController.v3.controller.MemberFormControllerV3;
+import hello.servlet.web.frontController.v3.controller.MemberListControllerV3;
+import hello.servlet.web.frontController.v3.controller.MemberSaveControllerV3;
+import hello.servlet.web.frontController.v4.controller.MemberFormControllerV4;
+import hello.servlet.web.frontController.v4.controller.MemberListControllerV4;
+import hello.servlet.web.frontController.v4.controller.MemberSaveControllerV4;
+import hello.servlet.web.frontController.v5.MyHandlerAdapter;
+
+import java.util.*;
+
+public class HandlerAdapterFactory {
+
+    private final Map<String, Object> handlerMappingMap = new HashMap<>();
+    private final List<MyHandlerAdapter> handlerAdapters = new ArrayList<>();
+
+    public HandlerAdapterFactory() {
+        initHandlerMappingMap();
+        initHandlerAdapters();
+    }
+
+    public Object getHandler(String requestURI) {
+        Object handler = handlerMappingMap.get(requestURI);
+
+        if (handler == null) {
+            throw new IllegalArgumentException("URI를 찾을 수 없습니다. URI: " + requestURI);
+        }
+
+        return handler;
+    }
+
+    public MyHandlerAdapter getAdapter(Object handler) {
+        return getHandlerAdapter(handler);
+    }
+
+    private void initHandlerMappingMap() {
+        handlerMappingMap.put("/front-controller/v5/v3/members/new-form", new MemberFormControllerV3());
+        handlerMappingMap.put("/front-controller/v5/v3/members/save", new MemberSaveControllerV3());
+        handlerMappingMap.put("/front-controller/v5/v3/members", new MemberListControllerV3());
+
+        handlerMappingMap.put("/front-controller/v5/v4/members/new-form", new MemberFormControllerV4());
+        handlerMappingMap.put("/front-controller/v5/v4/members/save", new MemberSaveControllerV4());
+        handlerMappingMap.put("/front-controller/v5/v4/members", new MemberListControllerV4());
+    }
+
+    private void initHandlerAdapters() {
+        handlerAdapters.add(new ControllerV3HandlerAdapter());
+        handlerAdapters.add(new ControllerV4HandlerAdapter());
+    }
+
+    private MyHandlerAdapter getHandlerAdapter(Object handler) {
+        for (MyHandlerAdapter adapter : handlerAdapters) {
+            if (adapter.supports(handler)) {
+                return adapter;
+            }
+        }
+
+        throw new IllegalArgumentException("Handler Adapter를 찾을 수 없습니다. handler: " + handler);
+    }
+}


### PR DESCRIPTION
# 프론트 컨트롤러(Front Controller) 패턴

#### 특징
- 프론트 컨트롤러 서블릿 하나로 클라이언트의 요청을 받는다.
- 프론트 컨트롤러가 요청에 맞는 컨트롤러를 찾아서 호출한다.
- 이렇게 하면 공통기능을 프론트 컨트롤러에서 처리할 수 있다.
- 프론트 컨드롤러를 제외한 나머지 컨트롤러는 서블릿을 사용하지 않아도 된다.

>스프링 웹 MVC의 DispatcherServlet이 FrontController 패턴으로 구현되어 있다.

## V1. 프론트 컨트롤러 도입

#### 기존 구조를 최대한 유지하면서 프론트 컨트롤러 도입

- 서블릿과 유사한 모양의 컨트롤러 인터페이스를 만든다.

- 컨트롤러 인터페이스를 구현한 3개의 컨트롤러를 만든다.
	+ 등록, 저장, 목록

- 프론트 컨트롤러 서블릿을 만든다.
	+ `urlPatterns = "/front-controller/v1/*"`를 통해 /front-controller/v1를 포함한 하위 모든 요청은 해당 서블릿에서 받는다.
	+ controllerMap을 통해 매핑 URL과 컨트롤러를 저장한다.

- HTTP 요청이 오면 service 메서드를 호출한다.
	+ URI를 통해 실제 호출한 컨트롤러를 controllerMap에서 찾는다.
	+ 없다면, SC_NOT_FOUNT(404) 상태 코드를 반환한다.
	+ 있다면, process 메서드를 호출해서 컨트롤러를 실행한다.

- 컨트롤러에서 forward를 통해 뷰로 이동한다.

>모든 요청을 프론트 컨트롤러 서블릿 하나로 받는다.

## V2. View 분류

#### 모든 컨트롤러에서 뷰로 이동하는 로직 분리 및 중복 제거

- 뷰를 처리하기 위한 클래스 MyView를 만든다.
	+ 생성자를 통해 JSP 물리 경로를 전달받는다.
	+ render 메서드는 뷰로 이동하는 로직은 수행한다.
	
- 각 컨트롤러 process 메서드의 반환값을 MyView로 수정한다.

- 프론트 컨트롤러에서는 process 메서드 실행 후, MyView 객체를 반환 받는다.

- 프론트 컨트롤러에서 반환받은 MyView의 render 메서드를 통해 뷰로 이동한다.

>- 컨트롤러에서 뷰로 이동하는 로직을 MyView로 분리
>- `HttpServletRequest.getRequestDispatcher(viewPath).forward(request, response)` 중복 로직 제거

## V3. Model 추가

#### Model을 추가하여 컨트롤러에서 서블릿 의존성 제거

- 서블릿 종석성 제거를 위한 ModelView를 만든다.
	+ 생성자를 통해 JSP의 논리 뷰 이름을 전달받는다.
	+ 뷰에서 필요한 데이터는 단순 Map으로 된 model에 저장한다.
	
- 각 컨트롤러 process 메서드의 인자 값을 Map으로, 반환값을 ModelView로 수정한다.

- 프론트 컨트롤러에는 공통 로직을 추가한다.
	+ createParamMap: HttpServletRequest에서 모든 파라미터를 추출해서 컨트롤러로 전달하는 로직
	+ viewResolver: 컨트롤러의 process 메서드를 통해 반환된 논리 뷰 이름을 물리 경로로 변경하여 MyView 객체를 반환하는 로직

- 반환받은 MyView의 render 메서드를 통해 뷰로 이동한다.
	+ render 메서드를 오버로딩하여 매개변수에 model이 추가된 메서드를 작성한다.
	+ model에 저장된 데이터를 HttpServletRequest.setAttribute()를 통해 저장한다.

>- 컨트롤러에서 서블릿 종속성(HttpServletRequest, HttpServletResponse) 제거
>- 컨트롤러에서 논리 뷰 이름을 반환하여, 물리 경로 중복값(/WEB-INF/views/, .jsp) 제거

## V4. 단순하고 실용적인 컨트롤러

기본적인 구조는 V3와 같지만, 컨트롤러가 ModelView를 반환하지 않고 논리 뷰 이름인 viewName를 직접 반환한다.
#### 구현 입장에서 ModelView를 직접 생성해서 반환하지 않도록 편리한 인터페이스 제공

- 컨트롤러 인터페이스의 process 메서드의 인자 값에 Map을 추가하고, 반환값을 String으로 수정한다.
	+ model을 파라미터로 전달하기 때문에, 직접 생성하지 않아도 된다.
	+ 각 컨트롤러는 논리 뷰 이름만 반환한다.
	
- process의 파라미터로 전달한 model과 반환값 viewName을 통해 MyView를 만들고, 뷰로 이동한다.

>뷰의 논리 이름을 반환하는 작은 변화를 통해 단순하고 실용적이게 컨트롤러를 구현 할 수 있다.
>
>프레임워크나 공통 기능이 수고로워야 사용하는 개발자가 편리해진다.

## V5. 유연한 컨트롤러

#### 어댑터를 추가해서 프레임워크를 유연하고 확장성 있게 설계
어댑터를 통해 V4뿐만 아니라 다른 버전의 컨트롤러 호출할 수 있다.

### 어댑터 패턴

- **한 클래스의 인터페이스를 클라이언트에서 사용하고자 하는 다른 인터페이스로 변환**
- 어댑터를 이용하면 인터페이스 호환성 문제 때문에 같이 쓸 수 없는 클래스들을 연결해서 사용할 수 있다.
	+ 클라이언트와 구현된 인터페이스를 분리시킬 수 있다.
	+ 향후 인터페이스가 변경되더라도, 그 변경 내역은 어댑터에 캡슐화 되기 때문에 클라이언트는 변경될 필요가 없다.

- 핸들러 어댑터: 중간에 어댑터 역할을 하는 클래스를 추가하여 다양한 종류의 컨트롤러를 호출할 수 있다.
- 핸들러: 어댑터를 통해 다양한 종류의 기능을 수행할 수 있다.

### 어댑터 도입

- 어댑터용 인터페이스인 MyHandlerAdapter를 만든다.
	+ 다형성 뿐만 아니라 어댑터의 가이드 역할을 한다.
	+ supports(): 어댑터가 해당 핸들러를 처리할 수 있는지 확인한다.
	+ hanlde(): 실제 핸들러를 호출하고, ModelView를 반환한다.
		+ 실제 핸들러가 ModelView를 반화하지 않더라도, 어댑터에서 ModelView를 생성해서 반환해야 한다.
	+ 프론트 컨트롤러는 이제 어댑터를 통해 실제 컨트롤러를 호출한다.
	
- 어댑터를 구현한다.
	+ V3 컨트롤러 어댑터는 `supports()`를 통해 V3 컨트롤러인지 확인한다.
	+ hanlde 메서드에서는 실제 컨트롤러의 process를 호출하고, 그 반환값을 프론트 컨트롤러로 반환한다.
		+ V4의 경우 컨트롤러에서 뷰의 논리 이름만 반환하므로 어댑터에서 ModelView를 만들어서 반환한다.
	
- 프론트 컨트롤러를 구현한다.
	+ `hadnlerMappingMap`에 매핑 URL과 매핑될 컨트롤러 인스턴스를 저장한다.
	+ 모든 어댑터를 `handlerAdapters`에 저장한다.
	+ HTTP 요청이 오면 매핑되는 URL이 있는지 확인한다.
	+ 매핑된 핸들러를 처리할 수 있는 어댑터가 있는지 확인한다.
	+ handle 메서드를 통해 어댑터를 호출한다.
		+ 실제 핸들러를 호출하고, 컨트롤러의 process를 수행한다.
	+ 반환받은 ModelView로 뷰로 이동한다.
	
>- 어댑터를 통해 다양한 인터페이스로 구현된 컨트롤러를 호출할 수 있다.
>- 또한, 핸들러와 어댑터를 추가하고, 프론트 컨트롤러에 주입하는 HandlerAdapterFactory 클래스를 만든다면 OCP를 지킬 수 있다.