### PR TITLE
스프링 MVC - 구조 이해

### DIFF
--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/old/MyHttpRequestHandler.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/old/MyHttpRequestHandler.java
@@ -1,0 +1,18 @@
+package hello.servlet.web.springmvc.old;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.HttpRequestHandler;
+
+import java.io.IOException;
+
+@Component("/springmvc/request-handler")
+public class MyHttpRequestHandler implements HttpRequestHandler {
+
+    @Override
+    public void handleRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        System.out.println("MyHttpRequestHandler.handleRequest");
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/old/OldController.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/old/OldController.java
@@ -15,6 +15,6 @@ public class OldController implements Controller {
     @Override
     public ModelAndView handleRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
         System.out.println("OldController.handleRequest");
-        return null;
+        return new ModelAndView("new-form");
     }
 }

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/old/OldController.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/old/OldController.java
@@ -1,0 +1,20 @@
+package hello.servlet.web.springmvc.old;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.Controller;
+
+/**
+ * http://localhost:8080/springmvc/old-controller
+ */
+@Component("/springmvc/old-controller")
+public class OldController implements Controller {
+
+    @Override
+    public ModelAndView handleRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        System.out.println("OldController.handleRequest");
+        return null;
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/v1/SpringMemberFormControllerV1.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/v1/SpringMemberFormControllerV1.java
@@ -1,0 +1,14 @@
+package hello.servlet.web.springmvc.v1;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+public class SpringMemberFormControllerV1 {
+
+    @RequestMapping("/springmvc/v1/members/new-form")
+    public ModelAndView process() {
+        return new ModelAndView("new-form");
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/v1/SpringMemberListControllerV1.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/v1/SpringMemberListControllerV1.java
@@ -1,0 +1,24 @@
+package hello.servlet.web.springmvc.v1;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.util.List;
+
+@Controller
+public class SpringMemberListControllerV1 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @RequestMapping("/springmvc/v1/members")
+    public ModelAndView process() {
+        List<Member> members = memberRepository.findAll();
+
+        ModelAndView mv = new ModelAndView("members");
+        mv.addObject("members", members);
+        return mv;
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/v1/SpringMemberSaveControllerV1.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/v1/SpringMemberSaveControllerV1.java
@@ -1,0 +1,28 @@
+package hello.servlet.web.springmvc.v1;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+public class SpringMemberSaveControllerV1 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @RequestMapping("/springmvc/v1/members/save")
+    public ModelAndView process(HttpServletRequest request, HttpServletResponse response) {
+        String username = request.getParameter("username");
+        int age = Integer.parseInt(request.getParameter("age"));
+
+        Member member = new Member(username, age);
+        memberRepository.save(member);
+
+        ModelAndView mv = new ModelAndView("save-result");
+        mv.addObject("member", member);
+        return mv;
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/v2/SpringMemberControllerV2.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/v2/SpringMemberControllerV2.java
@@ -1,0 +1,45 @@
+package hello.servlet.web.springmvc.v2;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/springmvc/v2/members")
+public class SpringMemberControllerV2 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @RequestMapping("/new-form")
+    public ModelAndView newForm() {
+        return new ModelAndView("new-form");
+    }
+
+    @RequestMapping("/save")
+    public ModelAndView save(HttpServletRequest request, HttpServletResponse response) {
+        String username = request.getParameter("username");
+        int age = Integer.parseInt(request.getParameter("age"));
+
+        Member member = new Member(username, age);
+        memberRepository.save(member);
+
+        ModelAndView mv = new ModelAndView("save-result");
+        mv.addObject("member", member);
+        return mv;
+    }
+
+    @RequestMapping
+    public ModelAndView members() {
+        List<Member> members = memberRepository.findAll();
+
+        ModelAndView mv = new ModelAndView("members");
+        mv.addObject("members", members);
+        return mv;
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/v3/SpringMemberControllerV3.java
+++ b/Spring-MVC-Part1/servlet/src/main/java/hello/servlet/web/springmvc/v3/SpringMemberControllerV3.java
@@ -1,0 +1,43 @@
+package hello.servlet.web.springmvc.v3;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.repository.MemberRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/springmvc/v3/members")
+public class SpringMemberControllerV3 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @GetMapping("/new-form")
+    public String newForm() {
+        return "new-form";
+    }
+
+    @PostMapping("/save")
+    public String save(@RequestParam("username") String username,
+                       @RequestParam("age") int age,
+                       Model model) {
+        Member member = new Member(username, age);
+        memberRepository.save(member);
+
+        model.addAttribute("member", member);
+        return "save-result";
+    }
+
+    @GetMapping
+    public String members(Model model) {
+        List<Member> members = memberRepository.findAll();
+
+        model.addAttribute("members", members);
+        return "members";
+    }
+}

--- a/Spring-MVC-Part1/servlet/src/main/resources/application.properties
+++ b/Spring-MVC-Part1/servlet/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-
+spring.mvc.view.prefix=/WEB-INF/views/
+spring.mvc.view.suffix=.jsp


### PR DESCRIPTION
# 스프링 MVC 구조

#### 기존 직접 만든 MVC 프레임워크 구조

![image](https://user-images.githubusercontent.com/50781066/232969490-1963d0d3-d01c-4e9c-912e-cd490edc0022.png)

#### SpringMVC 구조
 
![image](https://user-images.githubusercontent.com/50781066/232992057-f5a3ce14-3640-4ed7-95c5-9a572a97f9d4.png)

## 직접 만든 프레임워크 -> 스프링 MVC 비교

- FrontController -> DispatcherServlet
- handlerMappingMap -> HandlerMapping
- MyHandlerAdapter -> HandlerAdapter
- ModelView -> ModelAndView
- viewResolver -> ViewResolver
- MyView -> View 

## DispatcherServlet

- DispatcherServlet도 부모 클래스에서 HttpServlet을 상속받아 사용하는 서블릿이다.
	+ DispatcherServlet -> FrameworkServlet -> HttpServletBean -> HttpServlet
- DispatcherServlet은 서블릿으로 자동 등록하면서 모든경로(`urlPatterns="/"`)에 대해 매핑한다.

- 서블릿이 호출되면 HttpServlet이 제공하는 service 메서드가 호출된다.
	+ DispatcherServlet의 부모인 FrameworkServlet에서 service()를 오버라이드 한다.

- `FrameworkServlet.service()`를 시작으로 `DispatcherServlet.doDispatch()`가 호출된다.
	+ 핸들러를 조회한다.
		+ 핸들러 매핑을 통해 요청 URL에 매핑된 핸들러(컨트롤러)를 조회

#### 요청 흐름 
	
- 핸들러 어댑터를 조회한다.
	+ 핸들러를 실행할 수 있는 핸들러 어댑터를 조회
	
- 핸들러 어댑터를 실행한다.

- 핸들러 어댑터를 통해 실제 핸들러를 실행한다.

- ModelAndView를 반환한다.
	+  핸들러 어댑터는 핸들러가 반환하는 정보를 ModelAndView로 변환해서 반환

- viewResolver를 통해 뷰를 찾고 실행한다.

- View를 반환한다.
	+  뷰 리졸버는 뷰의 논리 이름을 물리 이름으로 바꾸고, 렌더링 역할을 담당하는 뷰 객체를 반환

- 뷰 렌더링한다.

>스프링 MVC는 대부분의 기능을 확장 가능하도록 인터페이스로 제공한다.
>따라서, DispatcherServlet 코드 변경없이 원하는 기능을 변경하거나 확장할 수 있다.
>
>주요 인터페이스 목록
>
>핸들러 매핑: org.springframework.web.servlet.HandlerMapping
>핸들러 어댑터: org.springframework.web.servlet.HandlerAdapter
>뷰 리졸버: org.springframework.web.servlet.ViewResolver
>뷰: org.springframework.web.servlet.View

## 핸드러 매핑과 핸드러 어댑터

### Controller 인터페이스

과저 버전 스프링에서는 Controller 인터페이스를 통해 컨트롤러를 구현했다.

- OldController에서는 `/springmvc/old-controller`라는 이름의 스프링 빈으로 등록되었다.
- `http://localhost:8080/springmvc/old-controller`를 실행해보면 빈 이름으로 URL이 매핑되는것을 확인할 수 있다.

#### 먼저 핸들러를 찾고(HandlerMapping), 핸들러를 실행할 어뎁터(HandlerAdapter)를 찾는 과정이 필요하다.

>스프링 부트가 자동으로 등록하는 핸들러 매핑과 핸들러 어댑터
>
>- HandlerMapping
>	+ RequestMappingHandlerMapping: 어노테이션 기반의 컨트롤러인 @ RequestMapping에서 사용한다.
>		+ 최근에는 대부분 어노테이션 기반의 핸들러 매핑을 사용한다.
>	+ BeanNameUrlHandlerMapping: 스프링 빈의 이름으로 핸들러를 찾는다.
>
>- HandlerAdapter
>	+ RequestMappingHandlerAdapter: 어노테이션 기반의 컨트롤러인 @ RequestMapping에서 사용한다.
>	+ HttpRequestHandlerAdapter: HttpRequestHandler를 처리한다.
>	+ SimpleControllerHandlerAdapter: Controller 인터페이스를 처리한다.
>
>실제로듣 더 많은 핸들러 매핑과 핸들러 어댑터를 등록한다.
	
#### 호출 과정

1. 핸들러 매핑으로 핸들러를 조회한다.
	- Controller 인터페이스를 사용하면 스프링 빈의 이름으로 핸들러를 찾아주는 `BeanNameUrlHandlerMapping`이 실행된다.
	- OldController를 반환한다.

2. 핸들러 어댑터 조회
	- HandlerAdapter의 supports 메서드를 통해 Controller 인터페이스를 지원하는 어댑터이 SimpleControllerHandlerAdapter를 반환한다.

3. 핸들러 어댑터 실행
	- DispatcherServlet이 조회한 SimpleControllerHandlerAdapter를 실행하면서 핸들러 정보도 함께 넘겨준다.
	- SimpleControllerHandlerAdapter는 OldController를 내부에서 실행하고, 그 결과를 반환한다.

### HttpRequestHandler

서블릿과 가장 유사한 형태의 핸들러다.

- MyHttpRequestHandler에서도 동일하게 `/springmvc/request-handler`라는 이름의 스프링 빈으로 등록한다.
- `http://localhost:8080/springmvc/request-handler`를 실행하면 빈 이름으로 URL 매핑이 된다.

#### 호출 과정

1. 빈 이름을 통한 핸들러 조회
	- `BeanNameUrlHandlerMapping`을 통해 MyHttpRequestHandler를 반환한다.

2. 핸들러 어댑터 조회
	- HttpRequestHandler를 지원하는 HttpRequestHandlerAdapter 반환한다.

3. 핸들러 어댑터 실행

## 뷰 리졸버

스프링 부트는 InternalResourceViewResolver를 자동으로 등록한다.
이때, application.properties에 등록한 `spring.mvc.view.prefix`, `spring.mvc.view.suffix` 설정 정보를 사용해서 등록한다.

```java
@Bean
ViewResolver internalResourceViewResolver() {
	return new InternalResourceViewResolver("/WEB-INF/views/", ".jsp");
}
```

>스프링 부트가 자동으로 등록하는 뷰 리졸버
>
>- BeanNameViewResolver: 빈 이름으로 뷰를 찾아서 반환한다.
>- InternalResourceViewResolver: JSP를 처리할 수 있는 뷰를 반환한다.
>
>실제로는 더 많은 뷰 리졸버를 등록한다.

### 동작 방식

1. 핸들러 어댑터 호출
	- 핸들러 어댑터를 통해 논리 뷰 이름인 `new-form`을 반환받는다.

2. ViewResolver 호출
	- `new-form`이름으로 viewResolver를 순서대로 호출한다.
	- BeanNameViewResolver에는 `new-form`으로 등록된 빈 이름이 없다.
	- InternalResourceViewResolver가 호출된다.

3. InternalResourceViewResolver
	- InternalResourceView를 반환한다.

4. InternalResourceView
	- JSP처럼 `forward()`를 호출해서 처리할 수 있는 경우 사용한다.

5. view.render()
	- `view.render()`가 호출되고 InternalResourceView는 forward메서드를 통해 JSP를 실행한다.

>참고
>
>InternalResourceViewResolver는 JSTL 라이브러리가 있다면 InternalResourceView를 상속받은 JstlView를 반환한다.
>`JstlView`는 JSTL 태그를 사용할 때 부가기능이 추가돼있다.
>
>JSP의 경우 forward()를 통해 JSP로 이동해야 렌더링 되지만, 다른 뷰 템플릿들은 forward()과정 없이 바로 렌더링 된다.

# 스프링 MVC

스프링이 제공하는 컨트롤러는 어노테이션 기반으로 동작해서, 유연하고 실용적이다.

>@ RequestMapping이 사용하는 RequestMappingHandlerMapping, RequestMappingHandlerAdapter는 가장 우선순위가 높은 핸들러 매핑과 핸들러 어댑터이다.

## V1. 어노테이션 기반 컨트롤러

- @ Controller
	+ 내부에 @ Component 어노테이션이 있다.
	+ 스프링이 자동으로 스프링 빈으로 등록한다.
	+ 스프링 MVC에서 어노테이션 기반 컨트롤러로 인식한다.
	
- @ RequestMapping
	+ 요청 정보를 매핑한다.
	+ 어노테이션 기반으로 동작하기 때문에, 메서드의 이름은 상관 없다.

- ModelAndView
	+ 모델과 뷰 정보를 담아서 반환한다.
	+ addObject()를 통해 Model 데이터를 추가한다.

>스프링 3.0 이전에는 클래스 레벨에 @ Controller 또는 @ RequestMapping이 있으면 컨트롤러로 인식했다.
>하지만 스프링 3.0 이상에서는 오직 @ Controller가 있어야 스프링 컨트롤러로 인식한다.

## V2. 컨트롤러 통합

- @ RequestMapping은 클래스 단위 뿐만 아니라 메서드 단위에도 적용할 수 있다.
- 따라서, 컨트롤러 클래스를 유연하게 하나로 통합할 수 있다.

- 각각 메서드 레벨에 @ RequestMapping을 사용하여 하나의 컨트롤러로 통합했다.
	+ 모든 메서드를 하나의 컨트롤러에서 관리하기보다는, 역할에 맞는 메서드들을 각각의 컨트롤러로 관리하는게 유지보수에 용이하다.
	
- @ RequestMapping을 클래스 레벨과 메서드 레벨을 조합하면 중복을 줄일 수 있다.
	+ 클래스 레벨: @ RequestMapping("/springmvc/v2/members")
	+ 메서드 레벨: @ RequestMapping("/new-form")
	+ `/springmvc/v2/members/new-form`과 매핑된다.
	
## V3. 실용적인 방식

- Model 파라미터
	+ 스프링 MVC에서 편의 기능을 제공한다.

- ViewName 직접 반환
	+ Model을 파라미터로 받기 때문에, 직접 생성해서 반환할 필요가 없다.
	+ 따라서, 뷰의 논리 이름을 반환할 수 있다.

- @ RequestParam 사용
	+ HttpServletRequest.getParameter()와 같은 기능을 한다.

- @ RequestMapping -> @ GetMapping, @ PostMapping
	+ @ RequestMapping은 URL 매핑 뿐만 아니라 HTTP Method도 구분할 수 있다.
	+ method 속성에 HTTP Method 타입을 설정하면 된다.
	+ @ + (HTTP Method Type) + Mapping의 형태로 더 편리하게 사용할 수 있다.
	+ 내부에는 해당 HTTP Method 타입으로 설정된 @ RequestMapping을 가지고 있다.