### PR TITLE
검증2 - Bean Validation

### DIFF
--- a/Spring-MVC-Part2/validation/build.gradle
+++ b/Spring-MVC-Part2/validation/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/domain/item/Item.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/domain/item/Item.java
@@ -1,13 +1,26 @@
 package hello.itemservice.domain.item;
 
 import lombok.Data;
+import org.hibernate.validator.constraints.Range;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Data
 public class Item {
 
     private Long id;
+
+    @NotBlank
     private String itemName;
+
+    @NotNull
+    @Range(min = 1000, max = 1000000)
     private Integer price;
+
+    @NotNull
+    @Max(9999)
     private Integer quantity;
 
     public Item() {

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/domain/item/Item.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/domain/item/Item.java
@@ -8,6 +8,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Data
+//@ScriptAssert(lang = "javascript", script = "_this.price * _this.quantity >= 10000")
 public class Item {
 
     private Long id;

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/domain/item/Item.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/domain/item/Item.java
@@ -8,20 +8,20 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Data
-//@ScriptAssert(lang = "javascript", script = "_this.price * _this.quantity >= 10000")
 public class Item {
 
+    @NotNull(groups = UpdateCheck.class)
     private Long id;
 
-    @NotBlank
+    @NotBlank(groups = {SaveCheck.class, UpdateCheck.class})
     private String itemName;
 
-    @NotNull
-    @Range(min = 1000, max = 1000000)
+    @NotNull(groups = {SaveCheck.class, UpdateCheck.class})
+    @Range(min = 1000, max = 1000000, groups = {SaveCheck.class, UpdateCheck.class})
     private Integer price;
 
-    @NotNull
-    @Max(9999)
+    @NotNull(groups = {SaveCheck.class, UpdateCheck.class})
+    @Max(value = 9999, groups = {SaveCheck.class})
     private Integer quantity;
 
     public Item() {

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/domain/item/SaveCheck.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/domain/item/SaveCheck.java
@@ -1,0 +1,4 @@
+package hello.itemservice.domain.item;
+
+public interface SaveCheck {
+}

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/domain/item/UpdateCheck.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/domain/item/UpdateCheck.java
@@ -1,0 +1,4 @@
+package hello.itemservice.domain.item;
+
+public interface UpdateCheck {
+}

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemApiController.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemApiController.java
@@ -1,0 +1,27 @@
+package hello.itemservice.web.validation;
+
+import hello.itemservice.web.validation.form.ItemSaveForm;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/validation/api/items")
+public class ValidationItemApiController {
+
+    @PostMapping("/add")
+    public Object addITem(@RequestBody @Validated ItemSaveForm form, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            log.info("검증 오류 발생 errors = {}", bindingResult);
+            return bindingResult.getAllErrors();
+        }
+
+        log.info("성공 로직 실행");
+        return form;
+    }
+}

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
@@ -1,0 +1,70 @@
+package hello.itemservice.web.validation;
+
+import hello.itemservice.domain.item.Item;
+import hello.itemservice.domain.item.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/validation/v3/items")
+@RequiredArgsConstructor
+public class ValidationItemControllerV3 {
+
+    private final ItemRepository itemRepository;
+
+    @GetMapping
+    public String items(Model model) {
+        List<Item> items = itemRepository.findAll();
+        model.addAttribute("items", items);
+        return "validation/v3/items";
+    }
+
+    @GetMapping("/{itemId}")
+    public String item(@PathVariable long itemId, Model model) {
+        Item item = itemRepository.findById(itemId);
+        model.addAttribute("item", item);
+        return "validation/v3/item";
+    }
+
+    @GetMapping("/add")
+    public String addForm(Model model) {
+        model.addAttribute("item", new Item());
+        return "validation/v3/addForm";
+    }
+
+    @PostMapping("/add")
+    public String addItem(@Validated @ModelAttribute Item item, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+        // 검증에 실패하면 다시 입력 폼으로
+        if (bindingResult.hasErrors()) {
+            return "validation/v3/addForm";
+        }
+
+        // 성공 로직
+        Item savedItem = itemRepository.save(item);
+        redirectAttributes.addAttribute("itemId", savedItem.getId());
+        redirectAttributes.addAttribute("status", true);
+        return "redirect:/validation/v3/items/{itemId}";
+    }
+
+    @GetMapping("/{itemId}/edit")
+    public String editForm(@PathVariable Long itemId, Model model) {
+        Item item = itemRepository.findById(itemId);
+        model.addAttribute("item", item);
+        return "validation/v3/editForm";
+    }
+
+    @PostMapping("/{itemId}/edit")
+    public String edit(@PathVariable Long itemId, @ModelAttribute Item item) {
+        itemRepository.update(itemId, item);
+        return "redirect:/validation/v3/items/{itemId}";
+    }
+
+}
+

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
@@ -69,7 +69,20 @@ public class ValidationItemControllerV3 {
     }
 
     @PostMapping("/{itemId}/edit")
-    public String edit(@PathVariable Long itemId, @ModelAttribute Item item) {
+    public String edit(@PathVariable Long itemId, @Validated @ModelAttribute Item item, BindingResult bindingResult) {
+        //특정 필드 예외가 아닌 전체 예외
+        if (item.getPrice() != null && item.getQuantity() != null) {
+            int resultPrice = item.getPrice() * item.getQuantity();
+            if (resultPrice < 10000) {
+                bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
+            }
+        }
+
+        // 검증에 실패하면 다시 입력 폼으로
+        if (bindingResult.hasErrors()) {
+            return "validation/v3/editForm";
+        }
+
         itemRepository.update(itemId, item);
         return "redirect:/validation/v3/items/{itemId}";
     }

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
@@ -41,6 +41,14 @@ public class ValidationItemControllerV3 {
 
     @PostMapping("/add")
     public String addItem(@Validated @ModelAttribute Item item, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+        //특정 필드 예외가 아닌 전체 예외
+        if (item.getPrice() != null && item.getQuantity() != null) {
+            int resultPrice = item.getPrice() * item.getQuantity();
+            if (resultPrice < 10000) {
+                bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
+            }
+        }
+
         // 검증에 실패하면 다시 입력 폼으로
         if (bindingResult.hasErrors()) {
             return "validation/v3/addForm";

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
@@ -2,6 +2,8 @@ package hello.itemservice.web.validation;
 
 import hello.itemservice.domain.item.Item;
 import hello.itemservice.domain.item.ItemRepository;
+import hello.itemservice.domain.item.SaveCheck;
+import hello.itemservice.domain.item.UpdateCheck;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -40,7 +42,7 @@ public class ValidationItemControllerV3 {
     }
 
     @PostMapping("/add")
-    public String addItem(@Validated @ModelAttribute Item item, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+    public String addItem(@Validated(SaveCheck.class) @ModelAttribute Item item, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
         //특정 필드 예외가 아닌 전체 예외
         if (item.getPrice() != null && item.getQuantity() != null) {
             int resultPrice = item.getPrice() * item.getQuantity();
@@ -69,7 +71,7 @@ public class ValidationItemControllerV3 {
     }
 
     @PostMapping("/{itemId}/edit")
-    public String edit(@PathVariable Long itemId, @Validated @ModelAttribute Item item, BindingResult bindingResult) {
+    public String edit(@PathVariable Long itemId, @Validated(UpdateCheck.class) @ModelAttribute Item item, BindingResult bindingResult) {
         //특정 필드 예외가 아닌 전체 예외
         if (item.getPrice() != null && item.getQuantity() != null) {
             int resultPrice = item.getPrice() * item.getQuantity();

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV4.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV4.java
@@ -1,0 +1,93 @@
+package hello.itemservice.web.validation;
+
+import hello.itemservice.domain.item.Item;
+import hello.itemservice.domain.item.ItemRepository;
+import hello.itemservice.domain.item.SaveCheck;
+import hello.itemservice.domain.item.UpdateCheck;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/validation/v4/items")
+@RequiredArgsConstructor
+public class ValidationItemControllerV4 {
+
+    private final ItemRepository itemRepository;
+
+    @GetMapping
+    public String items(Model model) {
+        List<Item> items = itemRepository.findAll();
+        model.addAttribute("items", items);
+        return "validation/v4/items";
+    }
+
+    @GetMapping("/{itemId}")
+    public String item(@PathVariable long itemId, Model model) {
+        Item item = itemRepository.findById(itemId);
+        model.addAttribute("item", item);
+        return "validation/v4/item";
+    }
+
+    @GetMapping("/add")
+    public String addForm(Model model) {
+        model.addAttribute("item", new Item());
+        return "validation/v4/addForm";
+    }
+
+    @PostMapping("/add")
+    public String addItem(@Validated(SaveCheck.class) @ModelAttribute Item item, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+        //특정 필드 예외가 아닌 전체 예외
+        if (item.getPrice() != null && item.getQuantity() != null) {
+            int resultPrice = item.getPrice() * item.getQuantity();
+            if (resultPrice < 10000) {
+                bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
+            }
+        }
+
+        // 검증에 실패하면 다시 입력 폼으로
+        if (bindingResult.hasErrors()) {
+            return "validation/v4/addForm";
+        }
+
+        // 성공 로직
+        Item savedItem = itemRepository.save(item);
+        redirectAttributes.addAttribute("itemId", savedItem.getId());
+        redirectAttributes.addAttribute("status", true);
+        return "redirect:/validation/v4/items/{itemId}";
+    }
+
+    @GetMapping("/{itemId}/edit")
+    public String editForm(@PathVariable Long itemId, Model model) {
+        Item item = itemRepository.findById(itemId);
+        model.addAttribute("item", item);
+        return "validation/v4/editForm";
+    }
+
+    @PostMapping("/{itemId}/edit")
+    public String edit(@PathVariable Long itemId, @Validated(UpdateCheck.class) @ModelAttribute Item item, BindingResult bindingResult) {
+        //특정 필드 예외가 아닌 전체 예외
+        if (item.getPrice() != null && item.getQuantity() != null) {
+            int resultPrice = item.getPrice() * item.getQuantity();
+            if (resultPrice < 10000) {
+                bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
+            }
+        }
+
+        // 검증에 실패하면 다시 입력 폼으로
+        if (bindingResult.hasErrors()) {
+            return "validation/v4/editForm";
+        }
+
+        itemRepository.update(itemId, item);
+        return "redirect:/validation/v4/items/{itemId}";
+    }
+
+}
+

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV4.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV4.java
@@ -2,8 +2,8 @@ package hello.itemservice.web.validation;
 
 import hello.itemservice.domain.item.Item;
 import hello.itemservice.domain.item.ItemRepository;
-import hello.itemservice.domain.item.SaveCheck;
-import hello.itemservice.domain.item.UpdateCheck;
+import hello.itemservice.web.validation.form.ItemSaveForm;
+import hello.itemservice.web.validation.form.ItemUpdateForm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -42,10 +42,10 @@ public class ValidationItemControllerV4 {
     }
 
     @PostMapping("/add")
-    public String addItem(@Validated(SaveCheck.class) @ModelAttribute Item item, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+    public String addItem(@Validated @ModelAttribute("item") ItemSaveForm form, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
         //특정 필드 예외가 아닌 전체 예외
-        if (item.getPrice() != null && item.getQuantity() != null) {
-            int resultPrice = item.getPrice() * item.getQuantity();
+        if (form.getPrice() != null && form.getQuantity() != null) {
+            int resultPrice = form.getPrice() * form.getQuantity();
             if (resultPrice < 10000) {
                 bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
             }
@@ -57,6 +57,11 @@ public class ValidationItemControllerV4 {
         }
 
         // 성공 로직
+        Item item = new Item();
+        item.setItemName(form.getItemName());
+        item.setPrice(form.getPrice());
+        item.setQuantity(form.getQuantity());
+
         Item savedItem = itemRepository.save(item);
         redirectAttributes.addAttribute("itemId", savedItem.getId());
         redirectAttributes.addAttribute("status", true);
@@ -71,10 +76,10 @@ public class ValidationItemControllerV4 {
     }
 
     @PostMapping("/{itemId}/edit")
-    public String edit(@PathVariable Long itemId, @Validated(UpdateCheck.class) @ModelAttribute Item item, BindingResult bindingResult) {
+    public String edit(@PathVariable Long itemId, @Validated @ModelAttribute("item") ItemUpdateForm form, BindingResult bindingResult) {
         //특정 필드 예외가 아닌 전체 예외
-        if (item.getPrice() != null && item.getQuantity() != null) {
-            int resultPrice = item.getPrice() * item.getQuantity();
+        if (form.getPrice() != null && form.getQuantity() != null) {
+            int resultPrice = form.getPrice() * form.getQuantity();
             if (resultPrice < 10000) {
                 bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
             }
@@ -85,7 +90,13 @@ public class ValidationItemControllerV4 {
             return "validation/v4/editForm";
         }
 
-        itemRepository.update(itemId, item);
+        Item itemParam = new Item();
+        itemParam.setId(form.getId());
+        itemParam.setItemName(form.getItemName());
+        itemParam.setPrice(form.getPrice());
+        itemParam.setQuantity(form.getQuantity());
+
+        itemRepository.update(itemId, itemParam);
         return "redirect:/validation/v4/items/{itemId}";
     }
 

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/form/ItemSaveForm.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/form/ItemSaveForm.java
@@ -1,0 +1,23 @@
+package hello.itemservice.web.validation.form;
+
+import lombok.Data;
+import org.hibernate.validator.constraints.Range;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+public class ItemSaveForm {
+
+    @NotBlank
+    private String itemName;
+
+    @NotNull
+    @Range(min = 1000, max = 1000000)
+    private Integer price;
+
+    @NotNull
+    @Max(9999)
+    private Integer quantity;
+}

--- a/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/form/ItemUpdateForm.java
+++ b/Spring-MVC-Part2/validation/src/main/java/hello/itemservice/web/validation/form/ItemUpdateForm.java
@@ -1,0 +1,24 @@
+package hello.itemservice.web.validation.form;
+
+import lombok.Data;
+import org.hibernate.validator.constraints.Range;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+public class ItemUpdateForm {
+
+    @NotNull
+    private Long id;
+
+    @NotBlank
+    private String itemName;
+
+    @NotNull
+    @Range(min = 1000, max = 1000000)
+    private Integer price;
+
+    // 수정에서 수량은 자유롭게 변경 가능
+    private Integer quantity;
+}

--- a/Spring-MVC-Part2/validation/src/main/resources/errors.properties
+++ b/Spring-MVC-Part2/validation/src/main/resources/errors.properties
@@ -37,3 +37,12 @@ max= {0} 까지 허용합니다.
 # typeMismatch
 typeMismatch.java.lang.Integer=숫자를 입력해주세요.
 typeMismatch=타입 오류입니다.
+
+# Bean Validation
+# Level1
+NotBlank.item.itemName=상품 이름을 입력해주세요.
+
+# Level4
+NotBlank={0} 공백X
+Range={0}, {2} ~ {1} 허용
+Max={0}, 최대 {1}

--- a/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v3/addForm.html
+++ b/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v3/addForm.html
@@ -1,0 +1,75 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <link th:href="@{/css/bootstrap.min.css}"
+          href="../css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .container {
+            max-width: 560px;
+        }
+        .field-error {
+            border-color: #dc3545;
+            color: #dc3545;
+        }
+    </style>
+</head>
+<body>
+
+<div class="container">
+
+    <div class="py-5 text-center">
+        <h2 th:text="#{page.addItem}">상품 등록</h2>
+    </div>
+
+    <form action="item.html" th:action th:object="${item}" method="post">
+
+        <div th:if="${#fields.hasGlobalErrors()}">
+            <p class="field-error" th:each="error : ${#fields.globalErrors()}"
+               th:text="${error}">글로벌 오류 메시지</p>
+        </div>
+
+        <div>
+            <label for="itemName" th:text="#{label.item.itemName}">상품명</label>
+            <input type="text" id="itemName" th:field="*{itemName}"
+                   th:errorclass="field-error" class="form-control" placeholder="이름을 입력하세요">
+            <div class="field-error" th:errors="*{itemName}">
+                상품명 오류
+            </div>
+        </div>
+        <div>
+            <label for="price" th:text="#{label.item.price}">가격</label>
+            <input type="text" id="price" th:field="*{price}"
+                   th:errorclass="field-error" class="form-control" placeholder="가격을 입력하세요">
+            <div class="field-error" th:errors="*{price}">
+                가격 오류
+            </div>
+        </div>
+        <div>
+            <label for="quantity" th:text="#{label.item.quantity}">수량</label>
+            <input type="text" id="quantity" th:field="*{quantity}"
+                   th:errorclass="field-error" class="form-control" placeholder="수량을 입력하세요">
+            <div class="field-error" th:errors="*{quantity}">
+                수량 오류
+            </div>
+        </div>
+
+        <hr class="my-4">
+
+        <div class="row">
+            <div class="col">
+                <button class="w-100 btn btn-primary btn-lg" type="submit" th:text="#{button.save}">상품 등록</button>
+            </div>
+            <div class="col">
+                <button class="w-100 btn btn-secondary btn-lg"
+                        onclick="location.href='items.html'"
+                        th:onclick="|location.href='@{/validation/v3/items}'|"
+                        type="button" th:text="#{button.cancel}">취소</button>
+            </div>
+        </div>
+
+    </form>
+
+</div> <!-- /container -->
+</body>
+</html>

--- a/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v3/editForm.html
+++ b/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v3/editForm.html
@@ -1,0 +1,57 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <link th:href="@{/css/bootstrap.min.css}"
+          href="../css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .container {
+            max-width: 560px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="container">
+
+    <div class="py-5 text-center">
+        <h2 th:text="#{page.updateItem}">상품 수정</h2>
+    </div>
+
+    <form action="item.html" th:action th:object="${item}" method="post">
+        <div>
+            <label for="id" th:text="#{label.item.id}">상품 ID</label>
+            <input type="text" id="id" th:field="*{id}" class="form-control" readonly>
+        </div>
+        <div>
+            <label for="itemName" th:text="#{label.item.itemName}">상품명</label>
+            <input type="text" id="itemName" th:field="*{itemName}" class="form-control">
+        </div>
+        <div>
+            <label for="price" th:text="#{label.item.price}">가격</label>
+            <input type="text" id="price" th:field="*{price}" class="form-control">
+        </div>
+        <div>
+            <label for="quantity" th:text="#{label.item.quantity}">수량</label>
+            <input type="text" id="quantity" th:field="*{quantity}" class="form-control">
+        </div>
+
+        <hr class="my-4">
+
+        <div class="row">
+            <div class="col">
+                <button class="w-100 btn btn-primary btn-lg" type="submit" th:text="#{button.save}">저장</button>
+            </div>
+            <div class="col">
+                <button class="w-100 btn btn-secondary btn-lg"
+                        onclick="location.href='item.html'"
+                        th:onclick="|location.href='@{/validation/v3/items/{itemId}(itemId=${item.id})}'|"
+                        type="button" th:text="#{button.cancel}">취소</button>
+            </div>
+        </div>
+
+    </form>
+
+</div> <!-- /container -->
+</body>
+</html>

--- a/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v3/editForm.html
+++ b/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v3/editForm.html
@@ -8,6 +8,10 @@
         .container {
             max-width: 560px;
         }
+        .field-error {
+            border-color: #dc3545;
+            color: #dc3545;
+        }
     </style>
 </head>
 <body>
@@ -19,21 +23,39 @@
     </div>
 
     <form action="item.html" th:action th:object="${item}" method="post">
+
+        <div th:if="${#fields.hasGlobalErrors()}">
+            <p class="field-error" th:each="error : ${#fields.globalErrors()}"
+               th:text="${error}">글로벌 오류 메시지</p>
+        </div>
+
         <div>
             <label for="id" th:text="#{label.item.id}">상품 ID</label>
             <input type="text" id="id" th:field="*{id}" class="form-control" readonly>
         </div>
         <div>
             <label for="itemName" th:text="#{label.item.itemName}">상품명</label>
-            <input type="text" id="itemName" th:field="*{itemName}" class="form-control">
+            <input type="text" id="itemName" th:field="*{itemName}"
+                   th:errorclass="field-error" class="form-control">
+            <div class="field-error" th:errors="*{itemName}">
+                상품명 오류
+            </div>
         </div>
         <div>
             <label for="price" th:text="#{label.item.price}">가격</label>
-            <input type="text" id="price" th:field="*{price}" class="form-control">
+            <input type="text" id="price" th:field="*{price}"
+                   th:errorclass="field-error" class="form-control">
+            <div class="field-error" th:errors="*{price}">
+                가격 오류
+            </div>
         </div>
         <div>
             <label for="quantity" th:text="#{label.item.quantity}">수량</label>
-            <input type="text" id="quantity" th:field="*{quantity}" class="form-control">
+            <input type="text" id="quantity" th:field="*{quantity}"
+                   th:errorclass="field-error" class="form-control">
+            <div class="field-error" th:errors="*{quantity}">
+                수량 오류
+            </div>
         </div>
 
         <hr class="my-4">

--- a/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v3/item.html
+++ b/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v3/item.html
@@ -1,0 +1,60 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <link th:href="@{/css/bootstrap.min.css}"
+          href="../css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .container {
+            max-width: 560px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="container">
+
+    <div class="py-5 text-center">
+        <h2 th:text="#{page.item}">상품 상세</h2>
+    </div>
+
+    <!-- 추가 -->
+    <h2 th:if="${param.status}" th:text="'저장 완료'"></h2>
+
+    <div>
+        <label for="itemId" th:text="#{label.item.id}">상품 ID</label>
+        <input type="text" id="itemId" name="itemId" class="form-control" value="1" th:value="${item.id}" readonly>
+    </div>
+    <div>
+        <label for="itemName" th:text="#{label.item.itemName}">상품명</label>
+        <input type="text" id="itemName" name="itemName" class="form-control" value="상품A" th:value="${item.itemName}" readonly>
+    </div>
+    <div>
+        <label for="price" th:text="#{label.item.price}">가격</label>
+        <input type="text" id="price" name="price" class="form-control" value="10000" th:value="${item.price}" readonly>
+    </div>
+    <div>
+        <label for="quantity" th:text="#{label.item.quantity}">수량</label>
+        <input type="text" id="quantity" name="quantity" class="form-control" value="10" th:value="${item.quantity}" readonly>
+    </div>
+
+    <hr class="my-4">
+
+    <div class="row">
+        <div class="col">
+            <button class="w-100 btn btn-primary btn-lg"
+                    onclick="location.href='editForm.html'"
+                    th:onclick="|location.href='@{/validation/v3/items/{itemId}/edit(itemId=${item.id})}'|"
+                    type="button" th:text="#{page.updateItem}">상품 수정</button>
+        </div>
+        <div class="col">
+            <button class="w-100 btn btn-secondary btn-lg"
+                    onclick="location.href='items.html'"
+                    th:onclick="|location.href='@{/validation/v3/items}'|"
+                    type="button" th:text="#{button.cancel}">목록으로</button>
+        </div>
+    </div>
+
+</div> <!-- /container -->
+</body>
+</html>

--- a/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v3/items.html
+++ b/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v3/items.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <link th:href="@{/css/bootstrap.min.css}"
+          href="../css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+
+<div class="container" style="max-width: 600px">
+    <div class="py-5 text-center">
+        <h2 th:text="#{page.items}">상품 목록</h2>
+    </div>
+
+    <div class="row">
+        <div class="col">
+            <button class="btn btn-primary float-end"
+                    onclick="location.href='addForm.html'"
+                    th:onclick="|location.href='@{/validation/v3/items/add}'|"
+                    type="button" th:text="#{page.addItem}">상품 등록</button>
+        </div>
+    </div>
+
+    <hr class="my-4">
+    <div>
+        <table class="table">
+            <thead>
+            <tr>
+                <th th:text="#{label.item.id}">ID</th>
+                <th th:text="#{label.item.itemName}">상품명</th>
+                <th th:text="#{label.item.price}">가격</th>
+                <th th:text="#{label.item.quantity}">수량</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="item : ${items}">
+                <td><a href="item.html" th:href="@{/validation/v3/items/{itemId}(itemId=${item.id})}" th:text="${item.id}">회원id</a></td>
+                <td><a href="item.html" th:href="@{|/validation/v3/items/${item.id}|}" th:text="${item.itemName}">상품명</a></td>
+                <td th:text="${item.price}">10000</td>
+                <td th:text="${item.quantity}">10</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+</div> <!-- /container -->
+
+</body>
+</html>

--- a/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v4/addForm.html
+++ b/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v4/addForm.html
@@ -1,0 +1,75 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <link th:href="@{/css/bootstrap.min.css}"
+          href="../css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .container {
+            max-width: 560px;
+        }
+        .field-error {
+            border-color: #dc3545;
+            color: #dc3545;
+        }
+    </style>
+</head>
+<body>
+
+<div class="container">
+
+    <div class="py-5 text-center">
+        <h2 th:text="#{page.addItem}">상품 등록</h2>
+    </div>
+
+    <form action="item.html" th:action th:object="${item}" method="post">
+
+        <div th:if="${#fields.hasGlobalErrors()}">
+            <p class="field-error" th:each="error : ${#fields.globalErrors()}"
+               th:text="${error}">글로벌 오류 메시지</p>
+        </div>
+
+        <div>
+            <label for="itemName" th:text="#{label.item.itemName}">상품명</label>
+            <input type="text" id="itemName" th:field="*{itemName}"
+                   th:errorclass="field-error" class="form-control" placeholder="이름을 입력하세요">
+            <div class="field-error" th:errors="*{itemName}">
+                상품명 오류
+            </div>
+        </div>
+        <div>
+            <label for="price" th:text="#{label.item.price}">가격</label>
+            <input type="text" id="price" th:field="*{price}"
+                   th:errorclass="field-error" class="form-control" placeholder="가격을 입력하세요">
+            <div class="field-error" th:errors="*{price}">
+                가격 오류
+            </div>
+        </div>
+        <div>
+            <label for="quantity" th:text="#{label.item.quantity}">수량</label>
+            <input type="text" id="quantity" th:field="*{quantity}"
+                   th:errorclass="field-error" class="form-control" placeholder="수량을 입력하세요">
+            <div class="field-error" th:errors="*{quantity}">
+                수량 오류
+            </div>
+        </div>
+
+        <hr class="my-4">
+
+        <div class="row">
+            <div class="col">
+                <button class="w-100 btn btn-primary btn-lg" type="submit" th:text="#{button.save}">상품 등록</button>
+            </div>
+            <div class="col">
+                <button class="w-100 btn btn-secondary btn-lg"
+                        onclick="location.href='items.html'"
+                        th:onclick="|location.href='@{/validation/v4/items}'|"
+                        type="button" th:text="#{button.cancel}">취소</button>
+            </div>
+        </div>
+
+    </form>
+
+</div> <!-- /container -->
+</body>
+</html>

--- a/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v4/editForm.html
+++ b/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v4/editForm.html
@@ -1,0 +1,79 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <link th:href="@{/css/bootstrap.min.css}"
+          href="../css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .container {
+            max-width: 560px;
+        }
+        .field-error {
+            border-color: #dc3545;
+            color: #dc3545;
+        }
+    </style>
+</head>
+<body>
+
+<div class="container">
+
+    <div class="py-5 text-center">
+        <h2 th:text="#{page.updateItem}">상품 수정</h2>
+    </div>
+
+    <form action="item.html" th:action th:object="${item}" method="post">
+
+        <div th:if="${#fields.hasGlobalErrors()}">
+            <p class="field-error" th:each="error : ${#fields.globalErrors()}"
+               th:text="${error}">글로벌 오류 메시지</p>
+        </div>
+
+        <div>
+            <label for="id" th:text="#{label.item.id}">상품 ID</label>
+            <input type="text" id="id" th:field="*{id}" class="form-control" readonly>
+        </div>
+        <div>
+            <label for="itemName" th:text="#{label.item.itemName}">상품명</label>
+            <input type="text" id="itemName" th:field="*{itemName}"
+                   th:errorclass="field-error" class="form-control">
+            <div class="field-error" th:errors="*{itemName}">
+                상품명 오류
+            </div>
+        </div>
+        <div>
+            <label for="price" th:text="#{label.item.price}">가격</label>
+            <input type="text" id="price" th:field="*{price}"
+                   th:errorclass="field-error" class="form-control">
+            <div class="field-error" th:errors="*{price}">
+                가격 오류
+            </div>
+        </div>
+        <div>
+            <label for="quantity" th:text="#{label.item.quantity}">수량</label>
+            <input type="text" id="quantity" th:field="*{quantity}"
+                   th:errorclass="field-error" class="form-control">
+            <div class="field-error" th:errors="*{quantity}">
+                수량 오류
+            </div>
+        </div>
+
+        <hr class="my-4">
+
+        <div class="row">
+            <div class="col">
+                <button class="w-100 btn btn-primary btn-lg" type="submit" th:text="#{button.save}">저장</button>
+            </div>
+            <div class="col">
+                <button class="w-100 btn btn-secondary btn-lg"
+                        onclick="location.href='item.html'"
+                        th:onclick="|location.href='@{/validation/v4/items/{itemId}(itemId=${item.id})}'|"
+                        type="button" th:text="#{button.cancel}">취소</button>
+            </div>
+        </div>
+
+    </form>
+
+</div> <!-- /container -->
+</body>
+</html>

--- a/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v4/item.html
+++ b/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v4/item.html
@@ -1,0 +1,60 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <link th:href="@{/css/bootstrap.min.css}"
+          href="../css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .container {
+            max-width: 560px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="container">
+
+    <div class="py-5 text-center">
+        <h2 th:text="#{page.item}">상품 상세</h2>
+    </div>
+
+    <!-- 추가 -->
+    <h2 th:if="${param.status}" th:text="'저장 완료'"></h2>
+
+    <div>
+        <label for="itemId" th:text="#{label.item.id}">상품 ID</label>
+        <input type="text" id="itemId" name="itemId" class="form-control" value="1" th:value="${item.id}" readonly>
+    </div>
+    <div>
+        <label for="itemName" th:text="#{label.item.itemName}">상품명</label>
+        <input type="text" id="itemName" name="itemName" class="form-control" value="상품A" th:value="${item.itemName}" readonly>
+    </div>
+    <div>
+        <label for="price" th:text="#{label.item.price}">가격</label>
+        <input type="text" id="price" name="price" class="form-control" value="10000" th:value="${item.price}" readonly>
+    </div>
+    <div>
+        <label for="quantity" th:text="#{label.item.quantity}">수량</label>
+        <input type="text" id="quantity" name="quantity" class="form-control" value="10" th:value="${item.quantity}" readonly>
+    </div>
+
+    <hr class="my-4">
+
+    <div class="row">
+        <div class="col">
+            <button class="w-100 btn btn-primary btn-lg"
+                    onclick="location.href='editForm.html'"
+                    th:onclick="|location.href='@{/validation/v4/items/{itemId}/edit(itemId=${item.id})}'|"
+                    type="button" th:text="#{page.updateItem}">상품 수정</button>
+        </div>
+        <div class="col">
+            <button class="w-100 btn btn-secondary btn-lg"
+                    onclick="location.href='items.html'"
+                    th:onclick="|location.href='@{/validation/v4/items}'|"
+                    type="button" th:text="#{button.cancel}">목록으로</button>
+        </div>
+    </div>
+
+</div> <!-- /container -->
+</body>
+</html>

--- a/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v4/items.html
+++ b/Spring-MVC-Part2/validation/src/main/resources/templates/validation/v4/items.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <link th:href="@{/css/bootstrap.min.css}"
+          href="../css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+
+<div class="container" style="max-width: 600px">
+    <div class="py-5 text-center">
+        <h2 th:text="#{page.items}">상품 목록</h2>
+    </div>
+
+    <div class="row">
+        <div class="col">
+            <button class="btn btn-primary float-end"
+                    onclick="location.href='addForm.html'"
+                    th:onclick="|location.href='@{/validation/v4/items/add}'|"
+                    type="button" th:text="#{page.addItem}">상품 등록</button>
+        </div>
+    </div>
+
+    <hr class="my-4">
+    <div>
+        <table class="table">
+            <thead>
+            <tr>
+                <th th:text="#{label.item.id}">ID</th>
+                <th th:text="#{label.item.itemName}">상품명</th>
+                <th th:text="#{label.item.price}">가격</th>
+                <th th:text="#{label.item.quantity}">수량</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="item : ${items}">
+                <td><a href="item.html" th:href="@{/validation/v4/items/{itemId}(itemId=${item.id})}" th:text="${item.id}">회원id</a></td>
+                <td><a href="item.html" th:href="@{|/validation/v4/items/${item.id}|}" th:text="${item.itemName}">상품명</a></td>
+                <td th:text="${item.price}">10000</td>
+                <td th:text="${item.quantity}">10</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+</div> <!-- /container -->
+
+</body>
+</html>

--- a/Spring-MVC-Part2/validation/src/test/java/hello/itemservice/validation/BeanValidationTest.java
+++ b/Spring-MVC-Part2/validation/src/test/java/hello/itemservice/validation/BeanValidationTest.java
@@ -1,0 +1,31 @@
+package hello.itemservice.validation;
+
+import hello.itemservice.domain.item.Item;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+public class BeanValidationTest {
+
+    @Test
+    void beanValidation() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+
+        Item item = new Item();
+        item.setItemName(" ");  // 공백
+        item.setPrice(0);
+        item.setQuantity(10000);
+
+        Set<ConstraintViolation<Item>> violations = validator.validate(item);
+        for (ConstraintViolation<Item> violation : violations) {
+            System.out.println("violation = " + violation);
+            System.out.println("violation = " + violation.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
# BeanValidation

#### BeanValidation을 활용하면 어노테이션 하나로 검증 로직을 편리하게 적용할 수 있다.

- 특정 구현체가 아닌 Bean Validation 2.0(JSR-380)이라는 기술 표준으로, 검증 어노테이션과 여러 인터페이스의 모음이다.
- 구현 기술은 일반적으로 하이버네이트 Validator를 사용한다.

- Bean Validation을 사용하기위해서는 의존관계를 추가해야한다.
	- `implementation 'org.springframework.boot:spring-boot-starter-validation'`
- 추가 라이브러리
	- `jakarta.validation-api`: Bean Validation 인터페이스
	- `hibernate-validator`: 구현체
	
## 검증 어노테이션

```
@Data
public class Item {

	...
	
	@NotBlank
	private String itemName;

	@NotNull
	@Range(min = 1000, max = 1000000)
	private Integer price;

	@NotNull
	@Max(9999) private Integer quantity;
	
	...
	
}
```
- `@NotBlank`: null + 빈값 + 공백만 있는 경우를 허용하지 않는다.
- `@NotNull`: null 을 허용하지 않는다.
- `@Range(min = 1000, max = 1000000)`: 범위 안의 값이어야 한다.
- `@Max(9999)`: 최대 9999까지만 허용한다.

>`javax.validation`에 의존한 어노테이션은 특정 구현과 관계없이 제공되는 표준 인터페이스이고,
>`org.hibernate.validator`에 의존한 어노테이션은 하이버네티으 validator 구현체를 사용할 때만 제공되는 검증기이다.

## BeanValidation 테스트

```
@Test
void beanValidation() {
	ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
	Validator validator = factory.getValidator();

	...

	Set<ConstraintViolation<Item>> violations = validator.validate(item);
	
	...
	
}
```

- 검증기 생성
- `Validation.buildDefaultValidatorFactory()`
	- `ValidationFactory` 인스턴스를 얻을 수 있다.
	- 내부적으로 `AbstractConfigurationImpl`의 `buildValidatorFactory()` 메서드를 실행한다.
- `factory.getValidator()`
	- `Validator` 인스턴스를 얻을 수 있다.

- 검증기 실행
- `validator.validate()`
	- 검증 대상을 검증기에 넣고 결과를 받는다.
	- `Set`에 `ConstraintViolation`이라는  검증 오류가 담긴다.
	- `Set`이 비어있다면, 오류가 없는 것이다.
	
- 검증 결과
- `ConstraintViolation` 결과에는 오류가 발생한 객체, 필드, 메시지 등 다양한 정보를 담고 있다.
```
violation={interpolatedMessage='공백일 수 없습니다', propertyPath=itemName, 
rootBeanClass=class hello.itemservice.domain.item.Item, 
messageTemplate='{javax.validation.constraints.NotBlank.message}'}
violation.message=공백일 수 없습니다
```

- 검증 순서
1. `ModelAttribute` 각각의 필드에 타입 변환 시도
	1. 성공하면 2번으로
	2. 실패하면 `typeMismatch`로 `FieldError` 추가
2. Validator 적용
	- 바인딩에 성공한 필드만 Bean Validation을 적용한다.
	- 객체에 정상적으로 값이 바인딩 됐을 때, 검증도 의미가 있다.

# 스프링 BeanValidation

- `spring-boot-starter-validation` 라이브러리를 추가하면 스프링 부트는 자동으로 Bean Validator르 인지하고, 스프링에 통합한다.
- 따라서, `@InitBinder`를 제거해도 어노테이션 기반의 Bean Validation이 정상 작동한다.

- 스프링 부트는 `LocalValidatorFactoryBean`을 글로벌 Validator로 등록한다.
- `LocalValidatorFactoryBean`는 `@NotNull`같은 어노테이션을 검증한다.
- 따라서 `@Valid`나 `@Validated`만 적용해도 정상 작동하는 것이다.
- 검증 오류가 발생하면, `FieldError`, `ObjectError`를 생성해서 `BindingResult`에 담아준다.

>직접 글로벌 Validator를 등록하면 스프링 부트는 Bean Validator를 글로벌 Validator로 등록하지 않는다.
>따라서, 어노테이션 기반 빈 검증기가 동작하지 않을 수 있다.

>검증시에는 `@Valid`나 `@Validated` 모두 사용할 수 있다.
>하지만 `javax.validation.@Valid`를 사용하려면 이전에 추가한 `spring-boot-starter-validation` 의존관계 추가가 필요하다.
>
>`@Validated`는 스프링 전용 검증 어노테이션이고, `@Valid`는 자바 표준 검증 어노테이션이다.

## 에러 코드

- Bean Validation이 기본으로 제공하는 오류 메시지 코드
	- `@NotBlank`
		- NotBlank.item.itemName
		- NotBlank.itemName
		- NotBlank.java.lang.String
		- NotBlank
- 위 처럼 어노테이션을 기반으로 오류 코드가 생성된다.
- 따라서, `typeMismatch`와 같이 메시지를 수정할 수 있다.
- `errors.properties`
```
# Level1
NotBlank.item.itemName=상품 이름을 입력해주세요.

# Level4
NotBlank={0} 공백X
Range={0}, {2} ~ {1} 허용
Max={0}, 최대 {1}
```
- `{0}`은 필드명이고, `{1}`, `{2}` ... 은 어노테이션마다 다르다.

## BeanValidation 메시지 찾는 순서

1. 생성된 메시지 코드 순서대로 `messageSource`에서 메시지를 찾는다.
2. 어노테이션의 `message` 속성을 사용한다.
	- `@NotBlank(message = "{0}, 공백은 입력할 수 없습니다.")` -> itemName, 공백은 입력할 수 없습니다.
3. 라이브러리가 제공하는 기본 값을 사용한다.
	- `공백일 수 없습니다.`
	
## 오브젝트 오류

- 하이버네이트에서는 오브젝트 관련 오류(`ObjectError`)를 처리하는 기능을 제공한다.
- `@ScriptAssert(lang=, script=, alias=, reportOn=)`
	- `lang`: JSR 233 Script Engine의 이름
	- `script`: 유혀성 검사 스크립트
	- `alias`: 객체의 별칭(기본 값 `this`)
	- `reportOn`: 특정 필드에 대한 유효성 검사(기본 값 `this`)

>`@ScriptAssert`는 제약사항이 많다.
>Script Engine도 Java의 버전에 따라 변경될 수 있다.
>(JDK 15부터 자바 엔진이 Nashorn -> GraalVM으로 변경되어 javascript를 사용할 수 없다.)
>
>따라서, 오브젝트 오류의 경우 직접 자바 코드로 작성하는 것을 권장한다.

# Bean Validation 한계

- 기존 요구사항
```
- 타입 검증
	-가격, 수량에 문자가 들어가면 검증 오류 처리
- 필드 검증
	- 상품명: 필수, 공백X
	- 가격: 1000원 이상, 1백만원 이하
	- 수량: 최대 9999
- 특정 필드의 범위를 넘어서는 검증
	- 가격 * 수량의 합은 10,000원 이상
```

#### 추가 요구사항
- 수정시에는 id 값이 필수
- 수정시에는 수량을 무제한으로 변경
	
```
public class Item {

    @NotNull
    private Long id;

    @NotBlank
    private String itemName;

    @NotNull
    @Range(min = 1000, max = 1000000)
    private Integer price;

    @NotNull
    private Integer quantity;
	
    ...

}	
```

- 위 처럼 코드를 수정하면 수정시에 추가 요구사항을 만족시킬 수 있다.
- 하지만 등록시에 문제가 발생한다.
	- 등록시에는 `id`가 없다.
	- 등록시에도 수량이 무제한으로 입력할 수 있다.
	- 따라서, 검증에 실패하고 다시 등록 폼 화면으로 넘어온다.

- 결과적으로 등록과 수정의 검증 조건에서 출돌이 발생한다.

## 해결방법

- 동일한 객체에서 각각 다르게 검증하는 방법은 2가지가 있다.
1. BeanValidation의 groups 기능을 사용한다.
2. 등록과 수정 폼 전송을 위한 각각 별도의 클래스를 만들어 사용한다.

### groups 사용

- 검증 집합을 제한하는 기능이다.
```
public interface SaveCheck {}
```
- 등록 검증 집합을 위한 인터페이스를 생성한다.

```
public interface UpdateCheck {}
```
- 수정 검증 집합을 위한 인터페이스를 생성한다.

```
public class Item {

    @NotNull(groups = UpdateCheck.class)
    private Long id;

    @NotBlank(groups = {SaveCheck.class, UpdateCheck.class})
    private String itemName;

    @NotNull(groups = {SaveCheck.class, UpdateCheck.class})
    @Range(min = 1000, max = 1000000, groups = {SaveCheck.class, UpdateCheck.class})
    private Integer price;

    @NotNull(groups = {SaveCheck.class, UpdateCheck.class})
    @Max(value = 9999, groups = {SaveCheck.class})
    private Integer quantity;

    ...
	
}
```
- `groups` 속성에 검증을 진행할 집합 클래스를 지정한다.

```
@Controller
@RequestMapping("/validation/v3/items")
public class ValidationItemControllerV3 {

    ...

    @PostMapping("/add")
    public String addItem(@Validated(SaveCheck.class) @ModelAttribute Item item, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
        
		...
		
    }

    @PostMapping("/{itemId}/edit")
    public String edit(@PathVariable Long itemId, @Validated(UpdateCheck.class) @ModelAttribute Item item, BindingResult bindingResult) {
	
		...
		
    }

}
```
- `Validated`의 `groups` 속성을 통해 검증받을 집합 클래스를 지정한다.

>`@Valid`에는 `groups` 기능이 없다.
>따라서, `groups`를 사용하려면 `@Validated`를 사용해야 한다.

### 별도의 클래스로 분리

```
public class Item {
	
	private Long id;
	private String itemName;
	private Integer price;
	private Integer quantity;
	
	...
}
```
- 기존 `Item` 클래스에서는 검증 코드를 삭제한다.

```
public class ItemSaveForm {

    @NotBlank
    private String itemName;

    @NotNull
    @Range(min = 1000, max = 1000000)
    private Integer price;

    @NotNull
    @Max(9999)
    private Integer quantity;
}
```
- 등록을 위한 필드를 만들고, 검증 코드를 추가한다.

```
public class ItemUpdateForm {

    @NotNull
    private Long id;

    @NotBlank
    private String itemName;

    @NotNull
    @Range(min = 1000, max = 1000000)
    private Integer price;

    // 수정에서 수량은 자유롭게 변경 가능
    private Integer quantity;
}
```
- 수정을 위한 필드를 만들고, 검증 코드를 추가한다.

```
@PostMapping("/add")
public String addItem(@Validated @ModelAttribute("item") ItemSaveForm form, BindingResult bindingResult, RedirectAttributes redirectAttributes) {

	...
	
}
```
- 등록 메서드에서 `Item` 대신 `ItemSaveForm`을 전달 받는다.
- `@Validated`로 검증도 수행하고, `BindingResult`로 검증 결과도 받는다.
- @ModelAttribute`의 이름을 `item`으로 넣으면 모델에 'item`으로 넘어가기 때문에 뷰 템플릿에도 기존처럼 `item`을 사용할 수 있다.

```
@PostMapping("/{itemId}/edit")
public String edit(@PathVariable Long itemId, @Validated @ModelAttribute("item") ItemUpdateForm form, BindingResult bindingResult) {

	...
	
}
```
- 수정 메서드에서 `Item` 대신 `ItemUpdateForm`을 전달 받고, 검증한다.
- 동일하게 `@ModelAttribute`의 이름을 `item`으로 지정하여 뷰 템플릿은 기존과 같은 방식으로 동작하도록 한다.

>대부분의 경우 등록과 수정을 위한 데이터가 도메인 객체와 딱 맞는경우는 드물다.
>도메인과 관계없는 부가 데이터가 넘어오는 경우도 많다.
>
>별도의 객체를 사용하면 폼 데이터를 기반으로 도메인으로 변환하는 과정이 필요하다.
>하지만 `groups`를 사용하면 전반적으로 코드의 복잡도가 증가한다.
>각각의 기능이 완전히 분리되기 때문에 폼 데이터가 복잡해도 거기에 맞춘 객체를 사용해서 데이터를 전달받을 수 있다.
>따라서 유지보수에 용이하다.

# HTTP Body 검증

- `@Valid`, `@Validated`는 `HttpMessageConverter`에도 적용할 수 있다.

>`@ModelAttribute`는 HTTP 요청 파라미터(URL 쿼리 스트링)를 다룰 때 사용한다.
>`@RequestBody`는 HTTP Body의 데이터를 객체로 변환할 때 사용한다.

- 사용방법은 동일하다.
```
@RestController
@RequestMapping("/validation/api/items")
public class ValidationItemApiController {
	@PostMapping("/add")
	public Object addItem(@RequestBody @Validated ItemSaveForm form, BindingResult bindingResult) {
	
		...
		
	}
	
	...
	 
}
```

#### 객체로 변환 실패

- `price` 값에 숫자가 아닌 문자를 전달한다면, `HttpMessageConverter`에서 요청 JSON을 객체로 생성하는데 실패한다.
- 이 경우 컨트롤러 자체가 호출되지 않고, 그 전에 예외가 발생한다.
- Validator도 실행되지 않는다.

#### 검증 오류

- `HttpMessageConverter`에서 객체로 변환은 성공했지만, 검증에 실패한 경우 `BindingResult`에 검증 오류가 담긴다.
- 이후 컨트롤러의 로직이 실행된다.

>`@ModelAttribute`는 HTTP 요청파라미터를 처리하기 위해 각각의 필드단위로 적용된다.
>따라서, 특정 필드에 타입이 맞지 않는 오류가 발생해도 나머지 필드는 정상 바인딩 되고, Validator를 통한 검증도 적용할 수 있다.
>
>하지만 `HttpMessageConverter`는 전체 객체 단위로 적용된다.
>따라서, 메시지 컨버터에 의해 객체를 만들어야만 `@Valid`, `@Validated`가 적용된다.