### PR TITLE
로그인 처리2 - 필터, 인터셉터

### DIFF
--- a/Spring-MVC-Part2/login/src/main/java/hello/login/WebConfig.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/WebConfig.java
@@ -1,6 +1,7 @@
 package hello.login;
 
 import hello.login.web.filter.LogFilter;
+import hello.login.web.filter.LoginCheckFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,16 @@ public class WebConfig {
         FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
         filterRegistrationBean.setFilter(new LogFilter());
         filterRegistrationBean.setOrder(1);
+        filterRegistrationBean.addUrlPatterns("/*");
+
+        return filterRegistrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<Filter> loginCheckFilter() {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new LoginCheckFilter());
+        filterRegistrationBean.setOrder(2);
         filterRegistrationBean.addUrlPatterns("/*");
 
         return filterRegistrationBean;

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/WebConfig.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/WebConfig.java
@@ -1,0 +1,22 @@
+package hello.login;
+
+import hello.login.web.filter.LogFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.servlet.Filter;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public FilterRegistrationBean<Filter> logFilter() {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new LogFilter());
+        filterRegistrationBean.setOrder(1);
+        filterRegistrationBean.addUrlPatterns("/*");
+
+        return filterRegistrationBean;
+    }
+}

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/WebConfig.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/WebConfig.java
@@ -1,13 +1,22 @@
 package hello.login;
 
+import hello.login.web.argumentresolver.LoginMemberArgumentResolver;
 import hello.login.web.interceptor.LogInterceptor;
 import hello.login.web.interceptor.LoginCheckInterceptor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginMemberArgumentResolver());
+    }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/WebConfig.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/WebConfig.java
@@ -1,6 +1,7 @@
 package hello.login;
 
 import hello.login.web.interceptor.LogInterceptor;
+import hello.login.web.interceptor.LoginCheckInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -14,5 +15,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .order(1)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/css/**", "/*.ico", "/error");
+
+        registry.addInterceptor(new LoginCheckInterceptor())
+                .order(2)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/", "/members/add", "/login", "/css/**", "/*.ico", "/error");
     }
 }

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/WebConfig.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/WebConfig.java
@@ -1,33 +1,18 @@
 package hello.login;
 
-import hello.login.web.filter.LogFilter;
-import hello.login.web.filter.LoginCheckFilter;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
+import hello.login.web.interceptor.LogInterceptor;
 import org.springframework.context.annotation.Configuration;
-
-import javax.servlet.Filter;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class WebConfig {
+public class WebConfig implements WebMvcConfigurer {
 
-    @Bean
-    public FilterRegistrationBean<Filter> logFilter() {
-        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
-        filterRegistrationBean.setFilter(new LogFilter());
-        filterRegistrationBean.setOrder(1);
-        filterRegistrationBean.addUrlPatterns("/*");
-
-        return filterRegistrationBean;
-    }
-
-    @Bean
-    public FilterRegistrationBean<Filter> loginCheckFilter() {
-        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
-        filterRegistrationBean.setFilter(new LoginCheckFilter());
-        filterRegistrationBean.setOrder(2);
-        filterRegistrationBean.addUrlPatterns("/*");
-
-        return filterRegistrationBean;
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LogInterceptor())
+                .order(1)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/css/**", "/*.ico", "/error");
     }
 }

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/web/HomeController.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/web/HomeController.java
@@ -1,14 +1,12 @@
 package hello.login.web;
 
 import hello.login.domain.member.Member;
+import hello.login.web.argumentresolver.Login;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.SessionAttribute;
-
-import static hello.login.web.SessionConst.LOGIN_MEMBER;
 
 @Slf4j
 @Controller
@@ -16,7 +14,7 @@ import static hello.login.web.SessionConst.LOGIN_MEMBER;
 public class HomeController {
 
     @GetMapping("/")
-    public String homeLogin(@SessionAttribute(name = LOGIN_MEMBER, required = false) Member loginMember, Model model) {
+    public String homeLogin(@Login Member loginMember, Model model) {
         // 세션에 회원 데이터가 없으면 home
         if (loginMember == null) {
             return "home";

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/web/argumentresolver/Login.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/web/argumentresolver/Login.java
@@ -1,0 +1,11 @@
+package hello.login.web.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/web/argumentresolver/LoginMemberArgumentResolver.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/web/argumentresolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,42 @@
+package hello.login.web.argumentresolver;
+
+import hello.login.domain.member.Member;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import static hello.login.web.SessionConst.LOGIN_MEMBER;
+
+@Slf4j
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        log.info("supportsParameter 실행");
+
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+        boolean hasMemberType = Member.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasLoginAnnotation && hasMemberType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        log.info("resolverArgument 실행");
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return null;
+        }
+
+        return session.getAttribute(LOGIN_MEMBER);
+    }
+}

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/web/filter/LogFilter.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/web/filter/LogFilter.java
@@ -1,0 +1,41 @@
+package hello.login.web.filter;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+public class LogFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        log.info("log filter init");
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        log.info("log filter doFilter");
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String requestURI = httpRequest.getRequestURI();
+
+        String uuid = UUID.randomUUID().toString();
+
+        try {
+            log.info("REQUEST [{}][{}}", uuid, requestURI);
+            chain.doFilter(request, response);
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            log.info("RESPONSE [{}][{}]", uuid, requestURI);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        log.info("log filter destroy");
+    }
+}

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/web/filter/LoginCheckFilter.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/web/filter/LoginCheckFilter.java
@@ -1,0 +1,55 @@
+package hello.login.web.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.PatternMatchUtils;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+import static hello.login.web.SessionConst.LOGIN_MEMBER;
+
+@Slf4j
+public class LoginCheckFilter implements Filter {
+
+    private static final String[] whitelist = {"/", "/members/add", "/login", "/css/*"};
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String requestURI = httpRequest.getRequestURI();
+
+        try {
+            log.info("인증 체크 필터 시작 {}", requestURI);
+
+            if (isLoginCheckPath(requestURI)) {
+                log.info("인증 체크 로직 실행 {}", requestURI);
+                HttpSession session = httpRequest.getSession(false);
+                if (session == null || session.getAttribute(LOGIN_MEMBER) == null) {
+                    log.info("미인증 사용자 요청 {}", requestURI);
+
+                    // 로그인 페이지로 redirect
+                    httpResponse.sendRedirect("/login?redirectURL=" + requestURI);
+                    return;
+                }
+            }
+
+            chain.doFilter(request, response);
+        } catch (Exception e) {
+            throw e;  // 예외 로깅 가능 하지만, 톰캣까지 예외를 보내주어야 한다.
+        } finally {
+            log.info("인증 체크 필터 종료 {}", requestURI);
+        }
+    }
+
+    /**
+     * 화이트 리스트의 경우 인증 체크 X
+     */
+    private boolean isLoginCheckPath(String requestURI) {
+        return !PatternMatchUtils.simpleMatch(whitelist, requestURI);
+    }
+}

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/web/interceptor/LogInterceptor.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/web/interceptor/LogInterceptor.java
@@ -1,0 +1,52 @@
+package hello.login.web.interceptor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.UUID;
+
+@Slf4j
+public class LogInterceptor implements HandlerInterceptor {
+
+    public static final String LOG_ID = "logId";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String requestURI = request.getRequestURI();
+        String uuid = UUID.randomUUID().toString();
+
+        request.setAttribute(LogInterceptor.LOG_ID, uuid);
+
+        // @RequestMapping: HandlerMethod
+        // 정적 리소스: ResourceRequestHandler
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod hm = (HandlerMethod) handler;  // 호출할 컨트롤러 메서드의 모든 정보가 포함되어 있다.
+            log.info("hm {}", hm);
+        }
+
+        log.info("REQUEST [{}][{}][{}]", uuid, requestURI, handler);
+
+        return true;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        log.info("postHandle [{}]", modelAndView);
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        String requestURI = request.getRequestURI();
+        String uuid = request.getAttribute(LOG_ID).toString();
+
+        log.info("RESPONSE [{}][{}][{}]", uuid, requestURI, handler);
+
+        if (ex != null) {
+            log.error("afterCompletion error!!", ex);
+        }
+    }
+}

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/web/interceptor/LoginCheckInterceptor.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/web/interceptor/LoginCheckInterceptor.java
@@ -1,0 +1,32 @@
+package hello.login.web.interceptor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import static hello.login.web.SessionConst.LOGIN_MEMBER;
+
+@Slf4j
+public class LoginCheckInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String requestURI = request.getRequestURI();
+
+        log.info("인증 체크 인터셉터 실행 {}", requestURI);
+
+        HttpSession session = request.getSession();
+
+        if (session == null || session.getAttribute(LOGIN_MEMBER) == null) {
+            log.info("미인증 사용자 요청");
+            // 로그인으로 redirect
+            response.sendRedirect("/login?redirectURL=" + requestURI);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Spring-MVC-Part2/login/src/main/java/hello/login/web/login/LoginController.java
+++ b/Spring-MVC-Part2/login/src/main/java/hello/login/web/login/LoginController.java
@@ -9,6 +9,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -29,7 +30,9 @@ public class LoginController {
     }
 
     @PostMapping("/login")
-    public String login(@Valid @ModelAttribute LoginForm form, BindingResult bindingResult, HttpServletRequest request) {
+    public String login(@Valid @ModelAttribute LoginForm form, BindingResult bindingResult,
+                        @RequestParam(defaultValue = "/") String redirectURL,
+                        HttpServletRequest request) {
         if (bindingResult.hasErrors()) {
             return "login/loginForm";
         }
@@ -50,7 +53,7 @@ public class LoginController {
         session.setMaxInactiveInterval(1800);
 
 
-        return "redirect:/";
+        return "redirect:" + redirectURL;
     }
 
     @PostMapping("/logout")


### PR DESCRIPTION
#### 공통 관신 사항

- 애플리케이션 여러 로직에서 공통으로 관심이 있는것을 ***공통 관심사(corss-cutting concern)***라고 한다.
- AOP, 서블릿 필터, 스프링 인터셉터를 사용할 수 있다.
- 웹 관련 공통 관심사를 처리할 때는 HTTP의 헤더나 URL 정보들이 필요하기 때문에 `HttpServletRequest`를 제공하는 서블릿 필터나 스프링 인터셉터를 사용하는 것이 좋다.

# 서블릿 필터

#### 필터 흐름
```
HTTP 요청 -> WAS -> 필터 -> 서블릿 -> 컨트롤러
```

- 필터를 적용하면 필터가 호출 된 다음 서블릿이 호출된다.
- 필터는 URL 패턴을 통해 필터의 적용범위를 적용할 수 있다.

#### 필터 체인
```
HTTP 요청 -> WAS -> 필터1 -> 필터2 -> 필터3 -> 서블릿 -> 컨트롤러
```

- 필터는 체인으로 구성되기 때문에, 중간에 필터를 자유롭게 추가할 수 있다.

## 필터 인터페이스

- 필터 인터페이스를 구현하고 등록하면 서블릿 컨테이너가 필터를 싱글톤 객체로 생성하고, 관리한다.
	- `init()`: 필터 초기화 메서드, 서블릿 컨테이너가 생성될 때 호출된다.
	- `doFilter()`: 요청이 올 때 마다 호출되는 메서드, 필터의 로직을 구현한다.
	- `destroy()`: 필터 종료 메서드, 서블릿 컨테이너가 종료될 때 호출된다.
	
### `doFilter()` 구현

```
public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException;
```

-  HTTP 요청이 오면 `doFilter`가 호출된다.

- `ServletRequest`: HTTP 요청이 아닌 경우까지 고려해서 만든 인터페이스다.
	- HTTP를 사용할 경우 `HttpServletRequest`로 다운 케스팅 해서 사용하면 된다.
	
- `chain`을 통해 다음 필터를 호출하고, 필터가 없으면 서블릿을 호출한다.
	- `chain.doFilter(request, response)`
	- 다음 필터나 서블릿을 호출할 때 `request`, `response`를 다른 객체로 변경할 수 있다.
	
## 필터 제한
```
HTTP 요청 -> WAS -> 필터 -> 서블릿 -> 컨트롤러  // 로그인 사용자
HTTP 요청 -> WAS -> 필터(적절하지 않은 요청에는 서블릿 호출X)
```

- 적절하지 않은 요청에는 서블릿을 호출하지 않고, 바로 응답을 반환할 수 있다.
- 따라서, 로그인 여부를 확인할 때 사용하기 좋다.

```
@Override
public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
	HttpServletRequest httpRequest = (HttpServletRequest) request;
	HttpServletResponse httpResponse = (HttpServletResponse) response;

	...

	try {
		if (isLoginCheckPath(requestURI)) {
			HttpSession session = httpRequest.getSession(false);
			if (session == null || session.getAttribute(LOGIN_MEMBER) == null) {
				// 미인증 사용자 로그인 페이지로 redirect
				httpResponse.sendRedirect("/login?redirectURL=" + requestURI);
				return;
			}
		}

		chain.doFilter(request, response);
	} catch (Exception e) {
		throw e;  // 예외 로깅 가능 하지만, 톰캣까지 예외를 보내주어야 한다.
	} finally {
		...
	}
}
```

- 필터에서 로그인이 필요한 URL인 경우에만 인증 체크 로직을 적용한다.
	- 로그인이 필요하지 않은 URL에 대해서는 인증 로직을 실행하지 않고, 다음 필터를 호출한다.
	
- 미인증 사용자의 경우 로그인 후에 원래 가려던 페이지로 이동할 수 있도록, `/login`에 쿼리 파라미터로 함께 전달한다.
- 로그인 페이지로 redirect 후 `return;`을 통해 필터나 서블릿, 컨트롤러가 더는 호출되지 않는다.

- `finally`부분은 모든 필터가 종료된 후 호출된다.

## 필터 등록

- 스프링 부트를 사용하면 `FilterRegistrationBean`에 추가한 후 스프링 빈으로 등록해서 사용할 수 있다.

- `setFilter(new LoginFilter())`: 등록할 필터를 지정한다.
- `setOrder(1)`: 필터는 체인으로 동작하기 때문에 순서가 필요하다.
- `addUrlPatterns("/*")`: 필터를 적용할 URL 패턴을 지정한다.
	- 한번에 여러 패턴을 지정할 수 있다.
	
>필터는 `chain.doFilter()`를 호출해서 다음 필터 또는 서블릿을 호출할 때, `request`, `response`를 다른 객체로 바꿀 수 있다.
>`ServletRequest`, `ServletResponse`를 구현한 다른 객체를 넘기면 다음 필터 또는 서블릿에서 사용된다.

# 스프링 인터셉터

- 서블릿 필토와 같이 웹과 관련된 공통 관심 사항을 해결할 수 있는 기술이다.
- 서블릿 필터는 서블릿이 제공하는 기술이라면, 스프링 인터셉터는 스프링 MVC가 제공하는 기술이다.
- 둘다 웹 관련 공통 관심사항을 처리하지만, 적용 순서와 범위, 사용방법이 다르다.

#### 스프링 인터셉터 흐름
```
HTTP 요청 -> WAS -> 필터 -> 서블릿 -> 스프링 인터셉터 -> 컨트롤러
```

- 스프링 인터셉터는 디스패처 서블릿과 컨트롤러 사이에서 컨트롤러 호출 직전 호출된다.
- 스프링 인터셉터도 URL 패턴을 적용할 수 있다.

#### 스프링 인터셉터 체인
```
HTTP 요청 -> WAS -> 필터 -> 서블릿 -> 인터셉터1 -> 인터셉터2 -> 컨트롤러
```

- 스프링 인터셉터는 체인으로 구성되기 때문에, 중간에 인터셉터를 자유롭게 추가할 수 있다.

## 스프링 인터셉터 인터페이스

![image](https://github.com/cyPark95/Spring-Study/assets/50781066/a5e94107-5ac8-40dc-9198-5647c82168bd)

- 필터는 `doFilter()` 하나만 제공되지만 인터셉터는 호출 전(`preHandle`), 호출 후(`postHandle`), 요청 완료 후(`afterCompletion`)으로 단계가 세분화 되어 있다.
	- `preHandle`: 컨트롤러 호출 전(핸들러 어댑터 호출 전)에 호출된다.
	- `postHandle`: 핸들러 어댑터 호출 후에 호출된다.
	- `afterCompletion`: 뷰가 렌더링 된 이후 호출된다.

#### 스프링 인터셉터 제한
```
HTTP 요청 -> WAS -> 필터 -> 서블릿 -> 스프링 인터셉터 -> 컨트롤러 //로그인 사용자
HTTP 요청 -> WAS -> 필터 -> 서블릿 -> 스프링 인터셉터(적절하지 않은 요청에는 컨트롤러 호출 X)
```

## 스프링 인터셉터 예외 발생

![image](https://github.com/cyPark95/Spring-Study/assets/50781066/1debaab8-5367-481a-b7df-21f181325905)

- `preHandle`: 컨트롤러 호출 전에 호출된다.
- `postHandle`: 컨트롤러에서 예외가 발생하면 `postHandle`은 호출되지 않는다.
- `afterCompletion`: 항상 호출된다.
	- 예외를 `ex` 파라미터로 받아서 예외 정보를 확인할 수 있다.
	
## 스프링 인터셉터 구현

- 스프링 인터셉터는 `HandlerInterceptor`를 구현한다.

- `preHandle`
```
@Override
public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
	
	...
	
	if (!isLogin(request)) {
		return false;
	}

	return true;
}
```

- `handler`: 호출할 컨트롤러 메서드의 정보를 가지고 있다.
	- `@RequestMapping`: `HandlerMethod`
	- 정적 리소스: `ResourceHttpRequestHandler`
- 반환값이 `true`이면 다음으로 진행하고, `false`이면 나머지 인터셉터는 물론, 핸들러 어댑터도 호출되지 않는다.

```
@Override
public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
	
	...
	
}
```

- `modelAndView`: 어떤 `modelAndView`가 반환되는지 응답 정보 가지고 있다.

```
@Override
public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
	
	...
	
}
```

- 예외가 발생하면 `postHandle`은 호출되지 않지만 `afterCompletion`은 반드시 호출된다.
- `ex`의 값은 `null`이지만 예외가 발생하면 에외 정보를 담고 있다.

## 인터셉터 등록

- 인터셉터는 `WebMvcConfigurer`가 제공하는 `addInterceptors()`를 사용해서 등록할 수 있다.

1. `WebMvcConfigurer`의 `addInterceptors(InterceptorRegistry registry)`를 구현한다.

2. `registry.addInterceptor(new LoginCheckInterceptor())`: 인터셉터 등록

3. `registry.order(1)`: 인터셉터 호출 순서 지정

4. `addPathPatterns("/**")`: 인터셉터를 적용할 URL 패턴을 지정

5. `excludePathPatterns("/css/**")`: 인터셉터에서 제외할 패턴을 지정

- `addPathPatterns`, `excludePathPatterns`를 통해 필터보다 더 정밀한 URL 패턴을 지정할 수 있다.

>스프링의 URL 경로
> - 스프링이 제공하는 URL 경로는 서블릿 기술이 제공하는 URL 경로와 완전히 다르다.
>
>```
>? 한 문자 일치
>* 경로(/) 안에서 0개 이상의 문자 일치
>** 경로 끝까지 0개 이상의 경로(/) 일치
>{spring} 경로(/)와 일치하고 spring이라는 변수로 캡처
>{spring:[a-z]+} matches the regexp [a-z]+ as a path variable named "spring"
>{spring:[a-z]+} regexp [a-z]+ 와 일치하고, "spring" 경로 변수로 캡처
>{*spring} 경로가 끝날 때 까지 0개 이상의 경로(/)와 일치하고 spring이라는 변수로 캡처
>```

# ArgumentResolver

- 스프링은 `ArgumentResolver`를 통해 컨트롤러가 필요로 하는 다양한 파라미터의 값을 생성한다.

- 어노테이션을 통해 사용자를 정보를 조회하고, 만들어주는 기능을 구현한다.

1. 어노테이션 생성

```
@Target(ElementType.PARAMETER)
@Retention(RetentionPolicy.RUNTIME)
public @interface Login { }
```

- `@Target`: 어노테이션 적용 범위 설정
	- `ElementType.PARAMETER`: 파라미터에만 사용
	
- `@Retention`: 어노테이션 유지 기간 설정
	- `RetentionPolicy.RUNTIME`: 런타임까지 애노테이션 정보 유지
	
2. ArgumentResolver 구현

```
public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {


    @Override
    public boolean supportsParameter(MethodParameter parameter) {
        
		...
		
    }

    @Override
    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
        
		...
		
    }
}
```
- `HandlerMethodArgumentResolver`를 구현한다.

- `supportsParameter()`: 지원 여부를 확인한다.
	- `ture`면 파라미터를 제공한다.

- `resolveArgument()`: 필요한 파라미터 정보를 생성한다.

3. `ArgumentResolver`를 등록

- `WebMvcConfigurer`구현체의 `addArgumentResolvers`를 통해 등록한다.


4. 적용
- `public String homeLogin(@Login Member loginMember, ...)`